### PR TITLE
Dart 2.17 enums refactoring

### DIFF
--- a/_tests/lib/compiler.dart
+++ b/_tests/lib/compiler.dart
@@ -1,5 +1,3 @@
-// @dart=2.9
-
 import 'dart:io';
 
 import 'package:build/build.dart';
@@ -56,9 +54,9 @@ final _ngFiles = Glob('lib/**.dart');
 Future<void> _testBuilder(
   Builder builder,
   Map<String, String> sourceAssets, {
-  List<AssetId> runBuilderOn,
-  void Function(LogRecord) onLog,
-  String rootPackage,
+  required List<AssetId> runBuilderOn,
+  required void Function(LogRecord) onLog,
+  String? rootPackage,
 }) async {
   // Setup the readers/writers for assets.
   final sources = InMemoryAssetReader(rootPackage: rootPackage);
@@ -75,13 +73,13 @@ Future<void> _testBuilder(
 
   // Load user sources.
   final writer = InMemoryAssetWriter();
-  final inputIds = runBuilderOn ?? [];
+  final inputIds = runBuilderOn;
   sourceAssets.forEach((serializedId, contents) {
     final id = makeAssetId(serializedId);
     sources.cacheStringAsset(id, contents);
-    if (runBuilderOn == null) {
-      inputIds.add(id);
-    }
+    // if (runBuilderOn == null) {
+    //   inputIds.add(id);
+    // }
   });
 
   if (inputIds.isEmpty) {
@@ -135,13 +133,13 @@ Future<void> _testBuilder(
 /// Note that `package:ngdart/**.dart` is always included.
 Future<void> compilesExpecting(
   String input, {
-  String inputSource,
-  Set<AssetId> runBuilderOn,
-  Map<String, String> include,
-  Object /*Matcher|Iterable<Matcher>*/ errors,
-  Object /*Matcher|Iterable<Matcher>*/ warnings,
-  Object /*Matcher|Iterable<Matcher>*/ notices,
-  Object /*Matcher|Map<String, Matcher>*/ outputs,
+  String? inputSource,
+  Set<AssetId>? runBuilderOn,
+  Map<String, String>? include,
+  Object? /*Matcher|Iterable<Matcher>*/ errors,
+  Object? /*Matcher|Iterable<Matcher>*/ warnings,
+  Object? /*Matcher|Iterable<Matcher>*/ notices,
+  Object? /*Matcher|Map<String, Matcher>*/ outputs,
 }) async {
   // Default values.
   //
@@ -181,7 +179,7 @@ void expectLogRecords(List<LogRecord> logs, matcher, String reasonPrefix) {
   if (matcher == null) {
     return;
   }
-  logs ??= [];
+  //logs ??= [];
   expect(logs.map(formattedLogMessage), matcher,
       reason:
           '$reasonPrefix: \n${logs.map((l) => '${formattedLogMessage(l)} at:\n ${l.stackTrace}')}');
@@ -200,9 +198,9 @@ String formattedLogMessage(LogRecord record) {
 /// An alias [compilesExpecting] with `errors` and `warnings` asserting empty.
 Future<void> compilesNormally(
   String input, {
-  String inputSource,
-  Map<String, String> include,
-  Set<AssetId> runBuilderOn,
+  String? inputSource,
+  Map<String, String>? include,
+  Set<AssetId>? runBuilderOn,
 }) =>
     compilesExpecting(
       input,

--- a/_tests/lib/compiler.dart
+++ b/_tests/lib/compiler.dart
@@ -54,7 +54,7 @@ final _ngFiles = Glob('lib/**.dart');
 Future<void> _testBuilder(
   Builder builder,
   Map<String, String> sourceAssets, {
-  required List<AssetId> runBuilderOn,
+  List<AssetId>? runBuilderOn,
   required void Function(LogRecord) onLog,
   String? rootPackage,
 }) async {
@@ -73,13 +73,13 @@ Future<void> _testBuilder(
 
   // Load user sources.
   final writer = InMemoryAssetWriter();
-  final inputIds = runBuilderOn;
+  final inputIds = runBuilderOn ?? [];
   sourceAssets.forEach((serializedId, contents) {
     final id = makeAssetId(serializedId);
     sources.cacheStringAsset(id, contents);
-    // if (runBuilderOn == null) {
-    //   inputIds.add(id);
-    // }
+    if (runBuilderOn == null) {
+      inputIds.add(id);
+    }
   });
 
   if (inputIds.isEmpty) {
@@ -175,11 +175,11 @@ Future<void> compilesExpecting(
   }
 }
 
-void expectLogRecords(List<LogRecord> logs, matcher, String reasonPrefix) {
+void expectLogRecords(List<LogRecord>? logs, matcher, String reasonPrefix) {
   if (matcher == null) {
     return;
   }
-  //logs ??= [];
+  logs ??= [];
   expect(logs.map(formattedLogMessage), matcher,
       reason:
           '$reasonPrefix: \n${logs.map((l) => '${formattedLogMessage(l)} at:\n ${l.stackTrace}')}');

--- a/_tests/test/compiler/ast_template_parser_test.dart
+++ b/_tests/test/compiler/ast_template_parser_test.dart
@@ -2622,7 +2622,7 @@ void main() {
 
 CompileDirectiveMetadata createCompileDirectiveMetadata({
   CompileTypeMetadata type,
-  CompileDirectiveMetadataType metadataType,
+  CompileDirectiveMetadataType metadataType = CompileDirectiveMetadataType.Directive,
   String selector,
   String exportAs,
   List<String> inputs,
@@ -2652,7 +2652,7 @@ CompileDirectiveMetadata createCompileDirectiveMetadata({
 
   return CompileDirectiveMetadata(
     type: type,
-    metadataType: metadataType ?? CompileDirectiveMetadataType.Directive,
+    metadataType: metadataType,
     selector: selector,
     exportAs: exportAs,
     inputs: inputsMap,

--- a/_tests/test/compiler/ast_template_parser_test.dart
+++ b/_tests/test/compiler/ast_template_parser_test.dart
@@ -2622,7 +2622,8 @@ void main() {
 
 CompileDirectiveMetadata createCompileDirectiveMetadata({
   CompileTypeMetadata type,
-  CompileDirectiveMetadataType metadataType = CompileDirectiveMetadataType.Directive,
+  CompileDirectiveMetadataType metadataType =
+      CompileDirectiveMetadataType.Directive,
   String selector,
   String exportAs,
   List<String> inputs,

--- a/ngast/lib/src/exception_handler/exceptions.dart
+++ b/ngast/lib/src/exception_handler/exceptions.dart
@@ -3,34 +3,48 @@ part of 'exception_handler.dart';
 @sealed
 enum ParserErrorCode {
   cannotFindMatchingClose('Cannot find matching close element to this'),
-  danglingCloseElement('Closing tag is dangling and no matching open tag can be found'),
+  danglingCloseElement(
+      'Closing tag is dangling and no matching open tag can be found'),
   duplicateStarDirective('Already found a *-directive, limit 1 per element.'),
-  duplicateSelectDecorator("Only 1 'select' decorator can exist in <ng-content>, found duplicate"),
-  duplicateProjectAsDecorator("Only 1 'ngProjectAs' decorator can exist in <ng-content>, found duplicate"),
-  duplicateReferenceDecorator('Only 1 reference decorator can exist in <ng-content>, found duplicate'),
+  duplicateSelectDecorator(
+      "Only 1 'select' decorator can exist in <ng-content>, found duplicate"),
+  duplicateProjectAsDecorator(
+      "Only 1 'ngProjectAs' decorator can exist in <ng-content>, found duplicate"),
+  duplicateReferenceDecorator(
+      'Only 1 reference decorator can exist in <ng-content>, found duplicate'),
   elementDecorator('Expected element decorator after whitespace'),
-  elementDecoratorAfterPrefix('Expected element decorator identifier after prefix'),
-  elementDecoratorSuffixBeforePrefix('Found special decorator suffix before prefix'),
+  elementDecoratorAfterPrefix(
+      'Expected element decorator identifier after prefix'),
+  elementDecoratorSuffixBeforePrefix(
+      'Found special decorator suffix before prefix'),
   elementDecoratorValue("Expected quoted value following '='"),
   elementDecoratorValueMissingQuotes('Decorator values must contain quotes'),
   elementIdentifier('Expected element tag name'),
-  expectedAfterElementIdentifier('Expected either whitespace or close tag end after element identifier'),
+  expectedAfterElementIdentifier(
+      'Expected either whitespace or close tag end after element identifier'),
   expectedEqualSign("Expected '=' between decorator and value"),
   expectedStandalone('Expected standalone token'),
   expectedTagClose('Expected tag close.'),
   // 'Catch-all' error code.
   expectedToken('Unexpected token'),
-  expectedWhitespaceBeforeNewDecorator('Expected whitespace before a new decorator'),
+  expectedWhitespaceBeforeNewDecorator(
+      'Expected whitespace before a new decorator'),
   emptyInterpolation('Interpolation expression cannot be empty'),
-  invalidDecoratorInNgContainer("Only '*' bindings are supported on <ng-container>"),
-  invalidDecoratorInNgContent("Only 'select' is a valid attribute/decorate in <ng-content>"),
+  invalidDecoratorInNgContainer(
+      "Only '*' bindings are supported on <ng-container>"),
+  invalidDecoratorInNgContent(
+      "Only 'select' is a valid attribute/decorate in <ng-content>"),
   invalidDecoratorInTemplate("Invalid decorator in 'template' element"),
-  invalidLetBindingInNoTemplate("'let-' binding can only be used in 'template' element"),
+  invalidLetBindingInNoTemplate(
+      "'let-' binding can only be used in 'template' element"),
   invalidMicroExpression('Failed parsing micro expression'),
   nonVoidElementUsingVoidEnd('Element is not a void-element'),
-  ngContentMustCLoseImmediately("'<ng-content ...>' must be followed immediately by close '</ng-content>'"),
-  propertyNameTooManyFixes("Property name can only be in format: 'name[.postfix[.unit]]"),
-  referenceIdentifierFound('Reference decorator only supports #<variable> on <ng-content>'),
+  ngContentMustCLoseImmediately(
+      "'<ng-content ...>' must be followed immediately by close '</ng-content>'"),
+  propertyNameTooManyFixes(
+      "Property name can only be in format: 'name[.postfix[.unit]]"),
+  referenceIdentifierFound(
+      'Reference decorator only supports #<variable> on <ng-content>'),
   suffixBanana("Expected closing banana ')]'"),
   suffixEvent("Expected closing parenthesis ')'"),
   suffixProperty("Expected closing bracket ']'"),
@@ -38,7 +52,8 @@ enum ParserErrorCode {
   unopenedMustache('Unopened mustache'),
   unterminatedComment('Unterminated comment'),
   unterminatedMustache('Unterminated mustache'),
-  voidElementInCloseTag('Void element identifiers cannot be used in close element tag'),
+  voidElementInCloseTag(
+      'Void element identifiers cannot be used in close element tag'),
   voidCloseInCloseTag("Void close '/>' cannot be used in a close element");
 
   final String message;

--- a/ngast/lib/src/exception_handler/exceptions.dart
+++ b/ngast/lib/src/exception_handler/exceptions.dart
@@ -1,6 +1,5 @@
 part of 'exception_handler.dart';
 
-@sealed
 enum ParserErrorCode {
   cannotFindMatchingClose('Cannot find matching close element to this'),
   danglingCloseElement(

--- a/ngast/lib/src/exception_handler/exceptions.dart
+++ b/ngast/lib/src/exception_handler/exceptions.dart
@@ -1,194 +1,45 @@
 part of 'exception_handler.dart';
 
 @sealed
-class ParserErrorCode {
-  static const cannotFindMatchingClose = ParserErrorCode._(
-    'CANNOT_FIND_MATCHING_CLOSE',
-    'Cannot find matching close element to this',
-  );
-
-  static const danglingCloseElement = ParserErrorCode._(
-    'DANGLING_CLOSE_ELEMENT',
-    'Closing tag is dangling and no matching open tag can be found',
-  );
-
-  static const duplicateStarDirective = ParserErrorCode._(
-    'DUPLICATE_STAR_DIRECTIVE',
-    'Already found a *-directive, limit 1 per element.',
-  );
-
-  static const duplicateSelectDecorator = ParserErrorCode._(
-    'DUPLICATE_SELECT_DECORATOR',
-    "Only 1 'select' decorator can exist in <ng-content>, found duplicate",
-  );
-
-  static const duplicateProjectAsDecorator = ParserErrorCode._(
-    'DUPLICATE_PROJECT_AS_DECORATOR',
-    "Only 1 'ngProjectAs' decorator can exist in <ng-content>, found duplicate",
-  );
-
-  static const duplicateReferenceDecorator = ParserErrorCode._(
-    'DUPLICATE_REFERENCE_DECORATOR',
-    'Only 1 reference decorator can exist in <ng-content>, found duplicate',
-  );
-
-  static const elementDecorator = ParserErrorCode._(
-    'ELEMENT_DECORATOR',
-    'Expected element decorator after whitespace',
-  );
-
-  static const elementDecoratorAfterPrefix = ParserErrorCode._(
-    'ELEMENT_DECORATOR_AFTER_PREFIX',
-    'Expected element decorator identifier after prefix',
-  );
-
-  static const elementDecoratorSuffixBeforePrefix = ParserErrorCode._(
-    'ELEMENT_DECORATOR',
-    'Found special decorator suffix before prefix',
-  );
-
-  static const elementDecoratorValue = ParserErrorCode._(
-    'ELEMENT_DECORATOR_VALUE',
-    "Expected quoted value following '='",
-  );
-
-  static const elementDecoratorValueMissingQuotes = ParserErrorCode._(
-    'ELEMENT_DECORATOR_VALUE_MISSING_QUOTES',
-    'Decorator values must contain quotes',
-  );
-
-  static const elementIdentifier = ParserErrorCode._(
-    'ELEMENT_IDENTIFIER',
-    'Expected element tag name',
-  );
-
-  static const expectedAfterElementIdentifier = ParserErrorCode._(
-    'EXPECTED_AFTER_ELEMENT_IDENTIFIER',
-    'Expected either whitespace or close tag end after element identifier',
-  );
-
-  static const expectedEqualSign = ParserErrorCode._(
-    'EXPECTED_EQUAL_SIGN',
-    "Expected '=' between decorator and value",
-  );
-
-  static const expectedStandalone = ParserErrorCode._(
-    'EXPECTING_STANDALONE',
-    'Expected standalone token',
-  );
-
-  static const expectedTagClose = ParserErrorCode._(
-    'EXPECTED_TAG_CLOSE',
-    'Expected tag close.',
-  );
-
+enum ParserErrorCode {
+  cannotFindMatchingClose('Cannot find matching close element to this'),
+  danglingCloseElement('Closing tag is dangling and no matching open tag can be found'),
+  duplicateStarDirective('Already found a *-directive, limit 1 per element.'),
+  duplicateSelectDecorator("Only 1 'select' decorator can exist in <ng-content>, found duplicate"),
+  duplicateProjectAsDecorator("Only 1 'ngProjectAs' decorator can exist in <ng-content>, found duplicate"),
+  duplicateReferenceDecorator('Only 1 reference decorator can exist in <ng-content>, found duplicate'),
+  elementDecorator('Expected element decorator after whitespace'),
+  elementDecoratorAfterPrefix('Expected element decorator identifier after prefix'),
+  elementDecoratorSuffixBeforePrefix('Found special decorator suffix before prefix'),
+  elementDecoratorValue("Expected quoted value following '='"),
+  elementDecoratorValueMissingQuotes('Decorator values must contain quotes'),
+  elementIdentifier('Expected element tag name'),
+  expectedAfterElementIdentifier('Expected either whitespace or close tag end after element identifier'),
+  expectedEqualSign("Expected '=' between decorator and value"),
+  expectedStandalone('Expected standalone token'),
+  expectedTagClose('Expected tag close.'),
   // 'Catch-all' error code.
-  static const expectedToken = ParserErrorCode._(
-    'UNEXPECTED_TOKEN',
-    'Unexpected token',
-  );
-
-  static const expectedWhitespaceBeforeNewDecorator = ParserErrorCode._(
-    'EXPECTED_WHITESPACE_BEFORE_DECORATOR',
-    'Expected whitespace before a new decorator',
-  );
-
-  static const emptyInterpolation = ParserErrorCode._(
-    'EMPTY_INTERPOLATION',
-    'Interpolation expression cannot be empty',
-  );
-
-  static const invalidDecoratorInNgContainer = ParserErrorCode._(
-    'INVALID_DECORATOR_IN_NGCONTAINER',
-    "Only '*' bindings are supported on <ng-container>",
-  );
-
-  static const invalidDecoratorInNgContent = ParserErrorCode._(
-    'INVALID_DECORATOR_IN_NGCONTENT',
-    "Only 'select' is a valid attribute/decorate in <ng-content>",
-  );
-
-  static const invalidDecoratorInTemplate = ParserErrorCode._(
-    'INVALID_DECORATOR_IN_TEMPLATE',
-    "Invalid decorator in 'template' element",
-  );
-
-  static const invalidLetBindingInNoTemplate = ParserErrorCode._(
-    'INVALID_LET_BINDING_IN_NONTEMPLATE',
-    "'let-' binding can only be used in 'template' element",
-  );
-
-  static const invalidMicroExpression = ParserErrorCode._(
-    'INVALID_MICRO_EXPRESSION',
-    'Failed parsing micro expression',
-  );
-
-  static const nonVoidElementUsingVoidEnd = ParserErrorCode._(
-    'NONVOID_ELEMENT_USING_VOID_END',
-    'Element is not a void-element',
-  );
-
-  static const ngContentMustCLoseImmediately = ParserErrorCode._(
-    'NGCONTENT_MUST_CLOSE_IMMEDIATElY',
-    "'<ng-content ...>' must be followed immediately by close '</ng-content>'",
-  );
-
-  static const propertyNameTooManyFixes = ParserErrorCode._(
-    'PROPERTY_NAME_TOO_MANY_FIXES',
-    "Property name can only be in format: 'name[.postfix[.unit]]",
-  );
-
-  static const referenceIdentifierFound = ParserErrorCode._(
-    'REFERENCE_IDENTIFIER_FOUND',
-    'Reference decorator only supports #<variable> on <ng-content>',
-  );
-
-  static const suffixBanana = ParserErrorCode._(
-    'SUFFIX_BANANA',
-    "Expected closing banana ')]'",
-  );
-
-  static const suffixEvent = ParserErrorCode._(
-    'SUFFIX_EVENT',
-    "Expected closing parenthesis ')'",
-  );
-
-  static const suffixProperty = ParserErrorCode._(
-    'SUFFIX_PROPERTY',
-    "Expected closing bracket ']'",
-  );
-
-  static const enclosedQuote = ParserErrorCode._(
-    'UNCLOSED_QUOTE',
-    'Expected close quote for element decorator value',
-  );
-
-  static const unopenedMustache = ParserErrorCode._(
-    'UNOPENED_MUSTACHE',
-    'Unopened mustache',
-  );
-
-  static const unterminatedComment = ParserErrorCode._(
-    'UNTERMINATED COMMENT',
-    'Unterminated comment',
-  );
-
-  static const unterminatedMustache = ParserErrorCode._(
-    'UNTERMINATED_MUSTACHE',
-    'Unterminated mustache',
-  );
-
-  static const voidElementInCloseTag = ParserErrorCode._(
-    'VOID_ELEMENT_IN_CLOSE_TAG',
-    'Void element identifiers cannot be used in close element tag',
-  );
-
-  static const voidCloseInCloseTag = ParserErrorCode._(
-    'VOID_CLOSE_IN_CLOSE_TAG',
-    "Void close '/>' cannot be used in a close element",
-  );
-
-  final String name;
+  expectedToken('Unexpected token'),
+  expectedWhitespaceBeforeNewDecorator('Expected whitespace before a new decorator'),
+  emptyInterpolation('Interpolation expression cannot be empty'),
+  invalidDecoratorInNgContainer("Only '*' bindings are supported on <ng-container>"),
+  invalidDecoratorInNgContent("Only 'select' is a valid attribute/decorate in <ng-content>"),
+  invalidDecoratorInTemplate("Invalid decorator in 'template' element"),
+  invalidLetBindingInNoTemplate("'let-' binding can only be used in 'template' element"),
+  invalidMicroExpression('Failed parsing micro expression'),
+  nonVoidElementUsingVoidEnd('Element is not a void-element'),
+  ngContentMustCLoseImmediately("'<ng-content ...>' must be followed immediately by close '</ng-content>'"),
+  propertyNameTooManyFixes("Property name can only be in format: 'name[.postfix[.unit]]"),
+  referenceIdentifierFound('Reference decorator only supports #<variable> on <ng-content>'),
+  suffixBanana("Expected closing banana ')]'"),
+  suffixEvent("Expected closing parenthesis ')'"),
+  suffixProperty("Expected closing bracket ']'"),
+  enclosedQuote('Expected close quote for element decorator value'),
+  unopenedMustache('Unopened mustache'),
+  unterminatedComment('Unterminated comment'),
+  unterminatedMustache('Unterminated mustache'),
+  voidElementInCloseTag('Void element identifiers cannot be used in close element tag'),
+  voidCloseInCloseTag("Void close '/>' cannot be used in a close element");
 
   final String message;
 
@@ -196,8 +47,5 @@ class ParserErrorCode {
   /// The message associated with the error will be created from the
   /// given [message] template. The correction associated with the error
   /// will be created from the given [correction] template.
-  const ParserErrorCode._(
-    this.name,
-    this.message,
-  );
+  const ParserErrorCode(this.message);
 }

--- a/ngast/lib/src/expression/micro/token.dart
+++ b/ngast/lib/src/expression/micro/token.dart
@@ -78,25 +78,17 @@ class NgMicroToken {
   final NgMicroTokenType type;
 
   @override
-  String toString() => '#$NgMicroToken(${type._name}) {$offset:$lexeme}';
+  String toString() => '#$NgMicroToken(${type.name}) {$offset:$lexeme}';
 }
 
-class NgMicroTokenType {
-  static const endExpression = NgMicroTokenType._('endExpression');
-  static const bindExpression = NgMicroTokenType._('bindExpression');
-  static const bindExpressionBefore = NgMicroTokenType._(
-    'bindExpressionBefore',
-  );
-  static const bindIdentifier = NgMicroTokenType._('bindIdentifier');
-  static const letAssignment = NgMicroTokenType._('letAssignment');
-  static const letAssignmentBefore = NgMicroTokenType._(
-    'letAssignmentBefore',
-  );
-  static const letIdentifier = NgMicroTokenType._('letIdentifier');
-  static const letKeyword = NgMicroTokenType._('letKeyword');
-  static const letKeywordAfter = NgMicroTokenType._('letKeywordAfter');
-
-  final String _name;
-
-  const NgMicroTokenType._(this._name);
+enum NgMicroTokenType {
+  endExpression,
+  bindExpression,
+  bindExpressionBefore,
+  bindIdentifier,
+  letAssignment,
+  letAssignmentBefore,
+  letIdentifier,
+  letKeyword,
+  letKeywordAfter
 }

--- a/ngast/lib/src/token/token_types.dart
+++ b/ngast/lib/src/token/token_types.dart
@@ -2,73 +2,79 @@ part of ngast.src.token.tokens;
 
 /// The types of tokens that can be returned by the NgStringTokenizer
 enum NgSimpleTokenType {
-  atSign,
-  bang,
-  backSlash,
-  closeBanana,
-  closeBrace,
-  closeBracket,
-  closeParen,
-  closeTagStart,
-  commentBegin,
-  commentEnd,
-  dash,
-  doubleQuote,
-  openTagStart,
-  tagEnd,
-  equalSign,
-  EOF,
-  forwardSlash,
-  hash,
-  identifier,
-  mustacheBegin,
-  mustacheEnd,
-  openBanana,
-  openBrace,
-  openBracket,
-  openParen,
-  period,
-  percent,
-  singleQuote,
-  star,
-  text,
-  unexpectedChar,
-  voidCloseTag,
-  whitespace,
+  atSign('@'),
+  bang('!'),
+  backSlash('\\'),
+  closeBanana(')]'),
+  closeBrace('}'),  // ???
+  closeBracket(']'),
+  closeParen(')'),
+  closeTagStart('</'),
+  commentBegin('<!--'),
+  commentEnd('-->'),
+  dash('-'),
+  doubleQuote('"'),
+  openTagStart('<'),
+  tagEnd('>'),
+  equalSign('='),
+  EOF(''),
+  forwardSlash('/'),
+  hash('#'),
+  identifier(''),
+  mustacheBegin('{{'),
+  mustacheEnd('}}'),
+  openBanana('[('),
+  openBrace('{'),  // ???
+  openBracket('['),
+  openParen('('),
+  period('.'),
+  percent('%'),
+  singleQuote("'"),
+  star('*'),
+  text(''),
+  unexpectedChar('?'),
+  voidCloseTag('/>'),
+  whitespace(' ');
+
+  final String symbols;
+  const NgSimpleTokenType(this.symbols);
 }
 
 /// The types of tokens that can be returned by the NgScanner.
 enum NgTokenType {
-  annotationPrefix,
-  bananaPrefix,
-  bananaSuffix,
-  bindPrefix, // Not used in NgScanner.
-  beforeElementDecorator,
-  beforeElementDecoratorValue,
-  closeElementEnd,
-  closeElementStart,
-  commentEnd,
-  commentStart,
-  commentValue,
-  doubleQuote,
-  elementDecorator,
-  elementDecoratorValue,
-  elementIdentifier,
-  eventPrefix,
-  eventSuffix,
-  interpolationEnd,
-  interpolationStart,
-  interpolationValue,
-  letPrefix,
-  openElementEnd,
-  openElementEndVoid,
-  openElementStart,
-  onPrefix, // Not used in NgScanner.
-  propertyPrefix,
-  propertySuffix,
-  referencePrefix,
-  singleQuote,
-  templatePrefix,
-  text,
-  whitespace,
+  annotationPrefix('@'),
+  bananaPrefix('[('),
+  bananaSuffix(')]'),
+  bindPrefix('bind-'), // Not used in NgScanner.
+  beforeElementDecorator(''),  // ???
+  beforeElementDecoratorValue('='),
+  closeElementEnd('>'),
+  closeElementStart('</'),
+  commentEnd('-->'),
+  commentStart('<!--'),
+  commentValue(''), // ???
+  doubleQuote('"'),
+  elementDecorator(''),  // ???
+  elementDecoratorValue(''),  // ???
+  elementIdentifier(''),  // ???
+  eventPrefix('('),
+  eventSuffix(')'),
+  interpolationEnd('}}'),
+  interpolationStart('{{'),
+  interpolationValue(''),  // ???
+  letPrefix('let-'),
+  openElementEnd('>'),
+  openElementEndVoid('/>'),
+  openElementStart('<'),
+  onPrefix('on-'), // Not used in NgScanner.
+  propertyPrefix('['),
+  propertySuffix(']'),
+  referencePrefix('#'),
+  singleQuote("'"),
+  templatePrefix('*'),
+  text(''),
+  whitespace(' ');
+
+  final String symbols;
+  const NgTokenType(this.symbols);
 }

--- a/ngast/lib/src/token/token_types.dart
+++ b/ngast/lib/src/token/token_types.dart
@@ -6,7 +6,7 @@ enum NgSimpleTokenType {
   bang('!'),
   backSlash('\\'),
   closeBanana(')]'),
-  closeBrace('}'),  // ???
+  closeBrace('}'),
   closeBracket(']'),
   closeParen(')'),
   closeTagStart('</'),
@@ -24,7 +24,7 @@ enum NgSimpleTokenType {
   mustacheBegin('{{'),
   mustacheEnd('}}'),
   openBanana('[('),
-  openBrace('{'),  // ???
+  openBrace('{'),
   openBracket('['),
   openParen('('),
   period('.'),
@@ -46,22 +46,22 @@ enum NgTokenType {
   bananaPrefix('[('),
   bananaSuffix(')]'),
   bindPrefix('bind-'), // Not used in NgScanner.
-  beforeElementDecorator(''),  // ???
+  beforeElementDecorator(''),
   beforeElementDecoratorValue('='),
   closeElementEnd('>'),
   closeElementStart('</'),
   commentEnd('-->'),
   commentStart('<!--'),
-  commentValue(''), // ???
+  commentValue(''),
   doubleQuote('"'),
-  elementDecorator(''),  // ???
-  elementDecoratorValue(''),  // ???
-  elementIdentifier(''),  // ???
+  elementDecorator(''),
+  elementDecoratorValue(''),
+  elementIdentifier(''),
   eventPrefix('('),
   eventSuffix(')'),
   interpolationEnd('}}'),
   interpolationStart('{{'),
-  interpolationValue(''),  // ???
+  interpolationValue(''),
   letPrefix('let-'),
   openElementEnd('>'),
   openElementEndVoid('/>'),

--- a/ngast/lib/src/token/tokens.dart
+++ b/ngast/lib/src/token/tokens.dart
@@ -15,37 +15,6 @@ abstract class NgBaseToken<T> {
 ///
 /// Clients should not extend, implement, or mix-in this class.
 class NgSimpleToken implements NgBaseToken<NgSimpleTokenType> {
-  static final Map<NgSimpleTokenType, String> lexemeMap = const {
-    NgSimpleTokenType.atSign: '@',
-    NgSimpleTokenType.backSlash: '\\',
-    NgSimpleTokenType.bang: '!',
-    NgSimpleTokenType.closeBanana: ')]',
-    NgSimpleTokenType.closeBracket: ']',
-    NgSimpleTokenType.closeParen: ')',
-    NgSimpleTokenType.closeTagStart: '</',
-    NgSimpleTokenType.commentBegin: '<!--',
-    NgSimpleTokenType.commentEnd: '-->',
-    NgSimpleTokenType.dash: '-',
-    NgSimpleTokenType.openTagStart: '<',
-    NgSimpleTokenType.tagEnd: '>',
-    NgSimpleTokenType.EOF: '',
-    NgSimpleTokenType.equalSign: '=',
-    NgSimpleTokenType.forwardSlash: '/',
-    NgSimpleTokenType.hash: '#',
-    NgSimpleTokenType.identifier: '',
-    NgSimpleTokenType.mustacheBegin: '{{',
-    NgSimpleTokenType.mustacheEnd: '}}',
-    NgSimpleTokenType.openBanana: '[(',
-    NgSimpleTokenType.openBracket: '[',
-    NgSimpleTokenType.openParen: '(',
-    NgSimpleTokenType.percent: '%',
-    NgSimpleTokenType.period: '.',
-    NgSimpleTokenType.star: '*',
-    NgSimpleTokenType.text: '',
-    NgSimpleTokenType.unexpectedChar: '?',
-    NgSimpleTokenType.voidCloseTag: '/>',
-    NgSimpleTokenType.whitespace: ' ',
-  };
 
   factory NgSimpleToken.atSign(int offset) {
     return NgSimpleToken._(NgSimpleTokenType.atSign, offset);
@@ -203,7 +172,7 @@ class NgSimpleToken implements NgBaseToken<NgSimpleTokenType> {
   @override
   final NgSimpleTokenType type;
   @override
-  String get lexeme => lexemeMap[type]!;
+  String get lexeme => type.symbols;
 
   @override
   String toString() => '#$NgSimpleToken($type) {$offset:$lexeme}';
@@ -279,32 +248,6 @@ class NgSimpleQuoteToken extends _LexemeNgSimpleToken {
 ///
 /// Clients should not extend, implement, or mix-in this class.
 class NgToken implements NgBaseToken<NgTokenType> {
-  static final Map<NgTokenType, String> lexemeMap = const {
-    NgTokenType.annotationPrefix: '@',
-    NgTokenType.bananaPrefix: '[(',
-    NgTokenType.bananaSuffix: ')]',
-    NgTokenType.beforeElementDecoratorValue: '=',
-    NgTokenType.bindPrefix: 'bind-',
-    NgTokenType.closeElementEnd: '>',
-    NgTokenType.closeElementStart: '</',
-    NgTokenType.commentEnd: '-->',
-    NgTokenType.commentStart: '<!--',
-    NgTokenType.doubleQuote: '"',
-    NgTokenType.eventPrefix: '(',
-    NgTokenType.eventSuffix: ')',
-    NgTokenType.interpolationEnd: '}}',
-    NgTokenType.interpolationStart: '{{',
-    NgTokenType.letPrefix: 'let-',
-    NgTokenType.openElementEnd: '>',
-    NgTokenType.openElementEndVoid: '/>',
-    NgTokenType.openElementStart: '<',
-    NgTokenType.onPrefix: 'on-',
-    NgTokenType.propertyPrefix: '[',
-    NgTokenType.propertySuffix: ']',
-    NgTokenType.referencePrefix: '#',
-    NgTokenType.singleQuote: "'",
-    NgTokenType.templatePrefix: '*',
-  };
 
   factory NgToken.generateErrorSynthetic(int offset, NgTokenType type,
       {String lexeme = ''}) {
@@ -486,7 +429,7 @@ class NgToken implements NgBaseToken<NgTokenType> {
 
   /// What characters were scanned and represent this token.
   @override
-  String get lexeme => lexemeMap[type]!;
+  String get lexeme => type.symbols;
 
   /// Indexed location where the token begins in the original source text.
   @override

--- a/ngast/lib/src/token/tokens.dart
+++ b/ngast/lib/src/token/tokens.dart
@@ -15,7 +15,6 @@ abstract class NgBaseToken<T> {
 ///
 /// Clients should not extend, implement, or mix-in this class.
 class NgSimpleToken implements NgBaseToken<NgSimpleTokenType> {
-
   factory NgSimpleToken.atSign(int offset) {
     return NgSimpleToken._(NgSimpleTokenType.atSign, offset);
   }
@@ -248,7 +247,6 @@ class NgSimpleQuoteToken extends _LexemeNgSimpleToken {
 ///
 /// Clients should not extend, implement, or mix-in this class.
 class NgToken implements NgBaseToken<NgTokenType> {
-
   factory NgToken.generateErrorSynthetic(int offset, NgTokenType type,
       {String lexeme = ''}) {
     if (type == NgTokenType.beforeElementDecorator ||

--- a/ngast/test/random_generator_test/random_tester.dart
+++ b/ngast/test/random_generator_test/random_tester.dart
@@ -96,7 +96,7 @@ String generateHtmlString() {
       case State.comment:
         if (type == NgSimpleTokenType.commentEnd) {
           state = State.text;
-          sb.write(NgSimpleToken.lexemeMap[type]);
+          sb.write(type.symbols);
         } else {
           sb.write(' some comment');
         }
@@ -104,7 +104,7 @@ String generateHtmlString() {
       case State.element:
         if (type == NgSimpleTokenType.commentBegin) {
           state = State.comment;
-          sb.write(NgSimpleToken.lexemeMap[type]);
+          sb.write(type.symbols);
         } else if (type == NgSimpleTokenType.doubleQuote) {
           sb.write('"someDoubleQuoteValue"');
         } else if (type == NgSimpleTokenType.singleQuote) {
@@ -117,15 +117,15 @@ String generateHtmlString() {
         } else if (type == NgSimpleTokenType.voidCloseTag ||
             type == NgSimpleTokenType.tagEnd) {
           state = State.text;
-          sb.write(NgSimpleToken.lexemeMap[type]);
+          sb.write(type.symbols);
         } else {
-          sb.write(NgSimpleToken.lexemeMap[type]);
+          sb.write(type.symbols);
         }
         break;
       case State.interpolation:
         if (type == NgSimpleTokenType.mustacheEnd) {
           state = State.text;
-          sb.write(NgSimpleToken.lexemeMap[type]);
+          sb.write(type.symbols);
         } else {
           sb.write(genericExpression);
         }
@@ -133,14 +133,14 @@ String generateHtmlString() {
       case State.text:
         if (type == NgSimpleTokenType.commentBegin) {
           state = State.comment;
-          sb.write(NgSimpleToken.lexemeMap[type]);
+          sb.write(type.symbols);
         } else if (type == NgSimpleTokenType.openTagStart ||
             type == NgSimpleTokenType.closeTagStart) {
           state = State.element;
-          sb.write(NgSimpleToken.lexemeMap[type]);
+          sb.write(type.symbols);
         } else if (type == NgSimpleTokenType.mustacheBegin) {
           state = State.interpolation;
-          sb.write('${NgSimpleToken.lexemeMap[type]}0');
+          sb.write('${type.symbols}0');
         } else {
           sb.write('lorem ipsum');
         }

--- a/ngast/test/recover_errors_lexer_test.dart
+++ b/ngast/test/recover_errors_lexer_test.dart
@@ -36,7 +36,7 @@ void testRecoverySolution(
 }) {
   var recoveryOffset = baseHtml.length;
 
-  for (var type in encounteredTokens) {
+  for (NgSimpleTokenType type in encounteredTokens) {
     var reader = NgTokenReversibleReader<Object>(null, []);
     var token = NgSimpleToken(type, recoveryOffset);
 
@@ -48,7 +48,7 @@ void testRecoverySolution(
     } else if (type == NgSimpleTokenType.identifier) {
       errorString = 'some-identifier';
     } else {
-      errorString = NgSimpleToken.lexemeMap[type]!;
+      errorString = type.symbols;
     }
     var errorHtml = baseHtml + errorString;
 

--- a/ngcompiler/lib/v1/src/compiler/angular_compiler.dart
+++ b/ngcompiler/lib/v1/src/compiler/angular_compiler.dart
@@ -101,7 +101,7 @@ class AngularCompiler {
     NormalizedComponentWithViewDirectives componentWithDirs,
   ) {
     return ir.Component(
-      componentWithDirs.component.type!.name,
+      componentWithDirs.component.type.name,
       encapsulation: _encapsulation(componentWithDirs),
       styles: componentWithDirs.component.template!.styles,
       styleUrls: componentWithDirs.component.template!.styleUrls,
@@ -135,7 +135,7 @@ class AngularCompiler {
       componentWithDirs.component.template!.template!,
       componentWithDirs.directives,
       componentWithDirs.pipes,
-      componentWithDirs.component.type!.name,
+      componentWithDirs.component.type.name,
       componentWithDirs.component.template!.templateUrl!,
     );
     return ir.ComponentView(
@@ -148,7 +148,7 @@ class AngularCompiler {
 
   ir.View _hostView(CompileDirectiveMetadata component) {
     var hostMeta = createHostComponentMeta(
-      component.type!,
+      component.type,
       component.selector!,
       component.analyzedClass,
       component.template!.preserveWhitespace,
@@ -158,21 +158,21 @@ class AngularCompiler {
       hostMeta.template!.template!,
       [component],
       [],
-      hostMeta.type!.name,
+      hostMeta.type.name,
       hostMeta.template!.templateUrl!,
     );
     return ir.HostView(
       cmpMetadata: hostMeta,
       parsedTemplate: parsedTemplate,
-      directiveTypes: createHostDirectiveTypes(component.type!),
+      directiveTypes: createHostDirectiveTypes(component.type),
     );
   }
 
   static String _moduleUrlFor(AngularArtifacts artifacts) {
     if (artifacts.components.isNotEmpty) {
-      return templateModuleUrl(artifacts.components.first.component.type!);
+      return templateModuleUrl(artifacts.components.first.component.type);
     } else if (artifacts.directives.isNotEmpty) {
-      return templateModuleUrl(artifacts.directives.first.type!);
+      return templateModuleUrl(artifacts.directives.first.type);
     } else {
       throw StateError('No components nor injectorModules given');
     }

--- a/ngcompiler/lib/v1/src/compiler/ast_directive_normalizer.dart
+++ b/ngcompiler/lib/v1/src/compiler/ast_directive_normalizer.dart
@@ -26,7 +26,7 @@ class AstDirectiveNormalizer {
     return CompileDirectiveMetadata.from(
       directive,
       template: await _normalizeTemplate(
-        directive.type!,
+        directive.type,
         directive.template,
       ),
     );

--- a/ngcompiler/lib/v1/src/compiler/compile_metadata.dart
+++ b/ngcompiler/lib/v1/src/compiler/compile_metadata.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:ngcompiler/v1/src/compiler/template_ast.dart';
 import 'package:ngdart/src/meta.dart';
 import 'package:ngcompiler/v1/cli.dart';
 import 'package:ngcompiler/v2/context.dart';
@@ -15,7 +16,7 @@ abstract class CompileMetadataWithIdentifier {
 }
 
 abstract class CompileMetadataWithType extends CompileMetadataWithIdentifier {
-  CompileTypeMetadata? get type;
+  CompileTypeMetadata get type;
 }
 
 class CompileIdentifierMetadata implements CompileMetadataWithIdentifier {
@@ -430,21 +431,24 @@ class CompileTemplateMetadata {
 
 enum CompileDirectiveMetadataType {
   /// Metadata type for a class annotated with `@Component`.
-  Component,
+  Component(ProviderAstType.Component),
 
   /// Metadata type for a class annotated with `@Directive`.
-  Directive,
+  Directive(ProviderAstType.Directive);
+
+  final ProviderAstType providerAstType;
+  const CompileDirectiveMetadataType(this.providerAstType);
 }
 
 /// Metadata regarding compilation of a directive.
 class CompileDirectiveMetadata implements CompileMetadataWithType {
   @override
-  final CompileTypeMetadata? type;
+  final CompileTypeMetadata type;
 
   /// User-land class where the component annotation originated.
   final CompileTypeMetadata? originType;
 
-  final CompileDirectiveMetadataType? metadataType;
+  final CompileDirectiveMetadataType metadataType;
   final String? selector;
   final String? exportAs;
   final int? changeDetection;
@@ -469,9 +473,9 @@ class CompileDirectiveMetadata implements CompileMetadataWithType {
   final bool isChangeDetectionLink;
 
   CompileDirectiveMetadata({
-    this.type,
+    required this.type,
     this.originType,
-    this.metadataType,
+    required this.metadataType,
     this.selector,
     this.exportAs,
     this.changeDetection,
@@ -654,14 +658,14 @@ List<CompileTypedMetadata> createHostDirectiveTypes(
 
 class CompilePipeMetadata implements CompileMetadataWithType {
   @override
-  final CompileTypeMetadata? type;
+  final CompileTypeMetadata type;
   final o.FunctionType? transformType;
   final String? name;
   final bool? pure;
   final List<LifecycleHooks> lifecycleHooks;
 
   CompilePipeMetadata({
-    this.type,
+    required this.type,
     this.transformType,
     this.name,
     this.pure = true,

--- a/ngcompiler/lib/v1/src/compiler/compile_metadata.dart
+++ b/ngcompiler/lib/v1/src/compiler/compile_metadata.dart
@@ -524,11 +524,11 @@ class CompileDirectiveMetadata implements CompileMetadataWithType {
   CompileIdentifierMetadata? get identifier => type;
 
   String toPrettyString() {
-    var name = type!.name;
+    var name = type.name;
     if (name.endsWith('Host')) {
       name = name.substring(0, name.length - 4);
     }
-    return '$name in ${type!.moduleUrl} '
+    return '$name in ${type.moduleUrl} '
         '(changeDetection: ${ChangeDetectionStrategy.toPrettyString(changeDetection!)})';
   }
 

--- a/ngcompiler/lib/v1/src/compiler/output/abstract_emitter.dart
+++ b/ngcompiler/lib/v1/src/compiler/output/abstract_emitter.dart
@@ -282,7 +282,7 @@ abstract class AbstractEmitterVisitor
     var name = expr.name;
     var builtin = expr.builtin;
     if (builtin != null) {
-      name = getBuiltinMethodName(builtin);
+      name = builtin.methodName;
     }
     if (expr.checked) {
       context.print('?');
@@ -312,9 +312,7 @@ abstract class AbstractEmitterVisitor
     context.print(')');
   }
 
-  String getBuiltinMethodName(o.BuiltinMethod method);
-
-  @override
+   @override
   void visitReadVarExpr(o.ReadVarExpr ast, EmitterVisitorContext context) {
     var varName = ast.name;
     if (ast.builtin != null) {
@@ -439,61 +437,10 @@ abstract class AbstractEmitterVisitor
       o.DeclareFunctionStmt stmt, EmitterVisitorContext context);
 
   @override
-  void visitBinaryOperatorExpr(
-      o.BinaryOperatorExpr ast, EmitterVisitorContext context) {
-    String opStr;
-    switch (ast.operator) {
-      case o.BinaryOperator.Equals:
-        opStr = '==';
-        break;
-      case o.BinaryOperator.Identical:
-        opStr = '===';
-        break;
-      case o.BinaryOperator.NotEquals:
-        opStr = '!=';
-        break;
-      case o.BinaryOperator.NotIdentical:
-        opStr = '!==';
-        break;
-      case o.BinaryOperator.And:
-        opStr = '&&';
-        break;
-      case o.BinaryOperator.Or:
-        opStr = '||';
-        break;
-      case o.BinaryOperator.Plus:
-        opStr = '+';
-        break;
-      case o.BinaryOperator.Minus:
-        opStr = '-';
-        break;
-      case o.BinaryOperator.Divide:
-        opStr = '/';
-        break;
-      case o.BinaryOperator.Multiply:
-        opStr = '*';
-        break;
-      case o.BinaryOperator.Modulo:
-        opStr = '%';
-        break;
-      case o.BinaryOperator.Lower:
-        opStr = '<';
-        break;
-      case o.BinaryOperator.LowerEquals:
-        opStr = '<=';
-        break;
-      case o.BinaryOperator.Bigger:
-        opStr = '>';
-        break;
-      case o.BinaryOperator.BiggerEquals:
-        opStr = '>=';
-        break;
-      default:
-        throw StateError('Unknown operator ${ast.operator}');
-    }
+  void visitBinaryOperatorExpr(o.BinaryOperatorExpr ast, EmitterVisitorContext context) {
     context.print('(');
     ast.lhs.visitExpression(this, context);
-    context.print(' $opStr ');
+    context.print(' ${ast.operator.opStr} ');
     ast.rhs.visitExpression(this, context);
     context.print(')');
   }

--- a/ngcompiler/lib/v1/src/compiler/output/abstract_emitter.dart
+++ b/ngcompiler/lib/v1/src/compiler/output/abstract_emitter.dart
@@ -312,7 +312,7 @@ abstract class AbstractEmitterVisitor
     context.print(')');
   }
 
-   @override
+  @override
   void visitReadVarExpr(o.ReadVarExpr ast, EmitterVisitorContext context) {
     var varName = ast.name;
     if (ast.builtin != null) {
@@ -437,7 +437,8 @@ abstract class AbstractEmitterVisitor
       o.DeclareFunctionStmt stmt, EmitterVisitorContext context);
 
   @override
-  void visitBinaryOperatorExpr(o.BinaryOperatorExpr ast, EmitterVisitorContext context) {
+  void visitBinaryOperatorExpr(
+      o.BinaryOperatorExpr ast, EmitterVisitorContext context) {
     context.print('(');
     ast.lhs.visitExpression(this, context);
     context.print(' ${ast.operator.opStr} ');

--- a/ngcompiler/lib/v1/src/compiler/output/output_ast.dart
+++ b/ngcompiler/lib/v1/src/compiler/output/output_ast.dart
@@ -147,21 +147,76 @@ abstract class TypeVisitor<R, C> {
 
 ///// Expressions
 enum BinaryOperator {
-  Equals,
-  NotEquals,
-  Identical,
-  NotIdentical,
-  Minus,
-  Plus,
-  Divide,
-  Multiply,
-  Modulo,
-  And,
-  Or,
-  Lower,
-  LowerEquals,
-  Bigger,
-  BiggerEquals
+  Equals('=='),
+  NotEquals('!='),
+  Identical('==='),
+  NotIdentical('!=='),
+  Minus('-'),
+  Plus('+'),
+  Divide('/'),
+  Multiply('*'),
+  Modulo('%'),
+  And('&&'),
+  Or('||'),
+  Lower('<'),
+  LowerEquals('<='),
+  Bigger('>'),
+  BiggerEquals('>=');
+
+  final String opStr;
+  const BinaryOperator(this.opStr);
+
+  static BinaryOperator? byOpStr(String opStr) {
+    BinaryOperator? retval = null;
+    switch (opStr) {
+      case '+':
+        retval = Plus;
+        break;
+      case '-':
+        retval = Minus;
+        break;
+      case '*':
+        retval = Multiply;
+        break;
+      case '/':
+        retval = Divide;
+        break;
+      case '%':
+        retval = Modulo;
+        break;
+      case '&&':
+        retval = And;
+        break;
+      case '||':
+        retval = Or;
+        break;
+      case '==':
+        retval = Equals;
+        break;
+      case '!=':
+        retval = NotEquals;
+        break;
+      case '===':
+        retval = Identical;
+        break;
+      case '!==':
+        retval = NotIdentical;
+        break;
+      case '<':
+        retval = Lower;
+        break;
+      case '>':
+        retval = Bigger;
+        break;
+      case '<=':
+        retval = LowerEquals;
+        break;
+      case '>=':
+        retval = BiggerEquals;
+        break;
+    }
+    return retval;
+  }
 }
 
 abstract class Expression {
@@ -453,7 +508,13 @@ class WritePropExpr extends Expression {
   }
 }
 
-enum BuiltinMethod { ConcatArray, SubscribeObservable }
+enum BuiltinMethod {
+  ConcatArray('.addAll'),
+  SubscribeObservable('listen');
+
+  final String methodName;
+  const BuiltinMethod(this.methodName);
+}
 
 class InvokeMethodExpr extends Expression {
   final Expression receiver;

--- a/ngcompiler/lib/v1/src/compiler/provider_parser.dart
+++ b/ngcompiler/lib/v1/src/compiler/provider_parser.dart
@@ -6,7 +6,6 @@ import 'compile_metadata.dart'
     show
         CompileDiDependencyMetadata,
         CompileDirectiveMetadata,
-        CompileDirectiveMetadataType,
         CompileProviderMetadata,
         CompileQueryMetadata,
         CompileTokenMap,
@@ -345,7 +344,7 @@ class ProviderElementContext implements ElementProviderUsage {
       // check @Host restriction
       if (result == null) {
         if (!dep.isHost ||
-            _rootProviderContext.component.type!.isHost ||
+            _rootProviderContext.component.type.isHost ||
             identifierToken(_rootProviderContext.component.type)
                 .equalsTo(dep.token!) ||
             _rootProviderContext.viewProviders.get(dep.token!) != null) {

--- a/ngcompiler/lib/v1/src/compiler/provider_parser.dart
+++ b/ngcompiler/lib/v1/src/compiler/provider_parser.dart
@@ -456,8 +456,7 @@ class _ProviderResolver {
           token: CompileTokenMetadata(identifier: directive.type),
           useClass: directive.type,
           visibility: directive.visibility);
-      final providerAstType =
-          _providerAstTypeFromMetadataType(directive.metadataType);
+      final providerAstType = directive.metadataType.providerAstType;
       _resolveProviders([dirProvider], providerAstType, eager: true);
     }
     // Note: We need an ordered list where components preceded directives so
@@ -553,19 +552,6 @@ void _addQueryToTokenMap(CompileTokenMap<List<CompileQueryMetadata>> map,
       map.add(token, entry);
     }
     entry.add(query);
-  }
-}
-
-ProviderAstType _providerAstTypeFromMetadataType(
-  CompileDirectiveMetadataType? type,
-) {
-  switch (type) {
-    case CompileDirectiveMetadataType.Component:
-      return ProviderAstType.Component;
-    case CompileDirectiveMetadataType.Directive:
-      return ProviderAstType.Directive;
-    default:
-      throw ArgumentError("Can't create '$ProviderAstType' from '$type'");
   }
 }
 

--- a/ngcompiler/lib/v1/src/compiler/template_optimize.dart
+++ b/ngcompiler/lib/v1/src/compiler/template_optimize.dart
@@ -46,7 +46,7 @@ void _typeNgForLocals(
   List<VariableAst> variables,
 ) {
   final ngFor = directives.firstWhereOrNull((directive) =>
-      directive.directive.type!.moduleUrl ==
+      directive.directive.type.moduleUrl ==
       Identifiers.NG_FOR_DIRECTIVE.moduleUrl);
   if (ngFor == null) return; // No `NgFor` to optimize.
   BoundExpression? ngForOfValue;

--- a/ngcompiler/lib/v1/src/compiler/template_parser.dart
+++ b/ngcompiler/lib/v1/src/compiler/template_parser.dart
@@ -165,13 +165,13 @@ List<T> removeDuplicates<T>(List<T> items) {
       if (r is CompilePipeMetadata) {
         CompilePipeMetadata rMeta = r;
         var itemMeta = item as CompilePipeMetadata;
-        return rMeta.type!.name == itemMeta.type!.name &&
-            rMeta.type!.moduleUrl == itemMeta.type!.moduleUrl;
+        return rMeta.type.name == itemMeta.type.name &&
+            rMeta.type.moduleUrl == itemMeta.type.moduleUrl;
       } else if (r is CompileDirectiveMetadata) {
         CompileDirectiveMetadata rMeta = r;
         var itemMeta = item as CompileDirectiveMetadata;
-        return rMeta.type!.name == itemMeta.type!.name &&
-            rMeta.type!.moduleUrl == itemMeta.type!.moduleUrl;
+        return rMeta.type.name == itemMeta.type.name &&
+            rMeta.type.moduleUrl == itemMeta.type.moduleUrl;
       } else {
         throw ArgumentError();
       }

--- a/ngcompiler/lib/v1/src/compiler/template_parser/ast_template_parser.dart
+++ b/ngcompiler/lib/v1/src/compiler/template_parser/ast_template_parser.dart
@@ -1238,7 +1238,7 @@ class _OnPushValidator extends InPlaceRecursiveTemplateVisitor<void> {
     if (!ast.skipOnPushValidation) {
       final componentAst = _ParseContext._firstComponent(ast.directives);
       if (componentAst != null && !componentAst.directive.isOnPush) {
-        final name = componentAst.directive.type!.name;
+        final name = componentAst.directive.type.name;
         logWarning(componentAst.sourceSpan.message(
           messages.warningForOnPushCompatibility(name),
         ));

--- a/ngcompiler/lib/v1/src/compiler/view_compiler/compile_view.dart
+++ b/ngcompiler/lib/v1/src/compiler/view_compiler/compile_view.dart
@@ -875,7 +875,7 @@ class CompileView {
       NodeReference elementRef,
       int nodeIndex,
       ElementAst ast) {
-    var childComponentType = childComponent.type!;
+    var childComponentType = childComponent.type;
     var componentViewIdentifier = CompileIdentifierMetadata(
         name: 'View${childComponentType.name}0',
         moduleUrl: templateModuleUrl(childComponentType));

--- a/ngcompiler/lib/v1/src/compiler/view_compiler/compile_view.dart
+++ b/ngcompiler/lib/v1/src/compiler/view_compiler/compile_view.dart
@@ -448,7 +448,7 @@ class CompileView {
     storage = CompileViewStorage();
     viewType = _getViewType(component, viewIndex);
     className = '${viewIndex == 0 && viewType != ViewType.host ? '' : '_'}'
-        'View${component.type!.name}$viewIndex';
+        'View${component.type.name}$viewIndex';
     classType = o.importType(CompileIdentifierMetadata(name: className))!;
     viewFactoryName = getViewFactoryName(component, viewIndex);
     viewFactory = getViewFactory(component, viewFactoryName);
@@ -1331,7 +1331,7 @@ class CompileView {
 
   void createPipeInstance(String name, CompilePipeMetadata pipeMeta) {
     var usesInjectorGet = false;
-    final deps = pipeMeta.type!.diDeps.map((diDep) {
+    final deps = pipeMeta.type.diDeps.map((diDep) {
       if (diDep.token!
           .equalsTo(identifierToken(Identifiers.ChangeDetectorRef))) {
         return o.THIS_EXPR;
@@ -1348,7 +1348,7 @@ class CompileView {
         o.StmtModifier.Final,
       ],
     );
-    final typeExpression = o.importExpr(pipeMeta.type!);
+    final typeExpression = o.importExpr(pipeMeta.type);
     if (usesInjectorGet) {
       _createMethod.addStmt(debugInjectorEnter(typeExpression));
     }
@@ -1620,7 +1620,7 @@ ViewType _getViewType(
     CompileDirectiveMetadata component, int embeddedTemplateIndex) {
   if (embeddedTemplateIndex > 0) {
     return ViewType.embedded;
-  } else if (component.type!.isHost) {
+  } else if (component.type.isHost) {
     return ViewType.host;
   } else {
     return ViewType.component;

--- a/ngcompiler/lib/v1/src/compiler/view_compiler/directive_compiler.dart
+++ b/ngcompiler/lib/v1/src/compiler/view_compiler/directive_compiler.dart
@@ -68,7 +68,7 @@ class DirectiveCompiler {
     NodeReference el,
   ) {
     final instanceType = o.importType(
-      directive.metadata!.type!.identifier,
+      directive.metadata!.type.identifier,
       directive.typeParameters!.map((t) => t.toType()).toList(),
     );
     storage.allocate(

--- a/ngcompiler/lib/v1/src/compiler/view_compiler/expression_converter.dart
+++ b/ngcompiler/lib/v1/src/compiler/view_compiler/expression_converter.dart
@@ -92,9 +92,9 @@ class _AstToExpressionVisitor
   o.Expression visitBinary(compiler_ast.Binary ast, _) {
     o.BinaryOperator? op = o.BinaryOperator.byOpStr(ast.operator);
     if (op == null) {
-        throw BuildError.withoutContext(
-          'Unsupported operation "${ast.operator}"',
-        );
+      throw BuildError.withoutContext(
+        'Unsupported operation "${ast.operator}"',
+      );
     } else {
       return o.BinaryOperatorExpr(
         op,

--- a/ngcompiler/lib/v1/src/compiler/view_compiler/expression_converter.dart
+++ b/ngcompiler/lib/v1/src/compiler/view_compiler/expression_converter.dart
@@ -90,63 +90,18 @@ class _AstToExpressionVisitor
 
   @override
   o.Expression visitBinary(compiler_ast.Binary ast, _) {
-    o.BinaryOperator op;
-    switch (ast.operator) {
-      case '+':
-        op = o.BinaryOperator.Plus;
-        break;
-      case '-':
-        op = o.BinaryOperator.Minus;
-        break;
-      case '*':
-        op = o.BinaryOperator.Multiply;
-        break;
-      case '/':
-        op = o.BinaryOperator.Divide;
-        break;
-      case '%':
-        op = o.BinaryOperator.Modulo;
-        break;
-      case '&&':
-        op = o.BinaryOperator.And;
-        break;
-      case '||':
-        op = o.BinaryOperator.Or;
-        break;
-      case '==':
-        op = o.BinaryOperator.Equals;
-        break;
-      case '!=':
-        op = o.BinaryOperator.NotEquals;
-        break;
-      case '===':
-        op = o.BinaryOperator.Identical;
-        break;
-      case '!==':
-        op = o.BinaryOperator.NotIdentical;
-        break;
-      case '<':
-        op = o.BinaryOperator.Lower;
-        break;
-      case '>':
-        op = o.BinaryOperator.Bigger;
-        break;
-      case '<=':
-        op = o.BinaryOperator.LowerEquals;
-        break;
-      case '>=':
-        op = o.BinaryOperator.BiggerEquals;
-        break;
-      default:
+    o.BinaryOperator? op = o.BinaryOperator.byOpStr(ast.operator);
+    if (op == null) {
         throw BuildError.withoutContext(
           'Unsupported operation "${ast.operator}"',
         );
+    } else {
+      return o.BinaryOperatorExpr(
+        op,
+        ast.left.visit(this, false /* visitingRoot */),
+        ast.right.visit(this, false /* visitingRoot */),
+      );
     }
-    return o.BinaryOperatorExpr(
-      op,
-      ast.left.visit(this, false /* visitingRoot */),
-      ast.right.visit(this, false /* visitingRoot */),
-    );
   }
 
   @override

--- a/ngcompiler/lib/v1/src/compiler/view_compiler/view_compiler.dart
+++ b/ngcompiler/lib/v1/src/compiler/view_compiler/view_compiler.dart
@@ -113,7 +113,7 @@ class ViewCompiler {
   /// These component factories are registered in `initReflector()` and used in
   /// user code.
   List<o.Statement> _registerComponentFactory(CompileView view) {
-    final componentTypeMetadata = view.component.type!;
+    final componentTypeMetadata = view.component.type;
     final componentType = o.importType(componentTypeMetadata)!;
     final componentName = componentTypeMetadata.name;
     final componentFactoryVar = o.variable('_${componentName}NgFactory');

--- a/ngcompiler/lib/v1/src/compiler/view_compiler/view_compiler_utils.dart
+++ b/ngcompiler/lib/v1/src/compiler/view_compiler/view_compiler_utils.dart
@@ -149,10 +149,10 @@ o.Expression debugInjectorWrap(o.Expression identifier, o.Expression wrap) =>
 /// Each generated view of [component], be it component, host, or embedded has
 /// an associated [index] that is used to distinguish between embedded views.
 String getViewFactoryName(CompileDirectiveMetadata component, int index) =>
-    _viewFactoryName(component.type!.name, index);
+    _viewFactoryName(component.type.name, index);
 
 String getHostViewFactoryName(CompileDirectiveMetadata component) =>
-    _viewFactoryName('${component.type!.name}Host', 0);
+    _viewFactoryName('${component.type.name}Host', 0);
 
 String _viewFactoryName(String componentName, int index) =>
     'viewFactory_$componentName$index';

--- a/ngcompiler/lib/v1/src/compiler/view_compiler/view_style_linker.dart
+++ b/ngcompiler/lib/v1/src/compiler/view_compiler/view_style_linker.dart
@@ -55,7 +55,7 @@ class _ViewStyleLinker {
           o.ReturnStatement(
             o.ConditionalExpr(
               o.importExpr(Runtime.isDevMode),
-              o.literal(_view.component.type!.moduleUrl),
+              o.literal(_view.component.type.moduleUrl),
               o.NULL_EXPR,
             ),
           ),

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
@@ -646,7 +646,7 @@ class _ComponentVisitor
     // assume they have at least defaults.
     var componentType = element.accept(
       CompileTypeMetadataVisitor(_library, directiveInfo, _exceptionHandler),
-    );
+    )!;
 
     final template = isComponent
         ? _createTemplateMetadata(directiveInfo, componentType)
@@ -922,7 +922,7 @@ void _errorOnUnusedDirectiveTypes(
 
   // The set of directives declared for use.
   var used =
-      directives.map((d) => key(d!.type!.moduleUrl, d.type!.name)).toSet();
+      directives.map((d) => key(d!.type.moduleUrl, d.type.name)).toSet();
 
   // Throw if the user attempts to type any directives that aren't used.
   for (var directiveType in directiveTypes) {

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
@@ -921,8 +921,7 @@ void _errorOnUnusedDirectiveTypes(
   String key(String? moduleUrl, String name) => '$moduleUrl#$name';
 
   // The set of directives declared for use.
-  var used =
-      directives.map((d) => key(d!.type.moduleUrl, d.type.name)).toSet();
+  var used = directives.map((d) => key(d!.type.moduleUrl, d.type.name)).toSet();
 
   // Throw if the user attempts to type any directives that aren't used.
   for (var directiveType in directiveTypes) {

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/pipe_visitor.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/pipe_visitor.dart
@@ -75,7 +75,7 @@ class PipeVisitor extends RecursiveElementVisitor<CompilePipeMetadata> {
     return CompilePipeMetadata(
       type: annotation.element.accept(
         CompileTypeMetadataVisitor(_library, annotation, _exceptionHandler),
-      ),
+      )!,
       transformType: fromFunctionType(transformType),
       name: coerceString(value, 'name'),
       pure: coerceBool(value, 'pure', defaultTo: true),

--- a/ngdart/lib/src/core/change_detection/differs/default_iterable_differ.dart
+++ b/ngdart/lib/src/core/change_detection/differs/default_iterable_differ.dart
@@ -723,7 +723,7 @@ class _DuplicateMap {
   /// first or second.
   CollectionChangeRecord? get(dynamic trackById, [int? afterIndex]) {
     var recordList = _map[trackById];
-    return recordList == null ? null : recordList.get(trackById, afterIndex);
+    return recordList?.get(trackById, afterIndex);
   }
 
   /// Removes a [CollectionChangeRecord] from the list of duplicates.

--- a/ngdart/lib/src/meta/view.dart
+++ b/ngdart/lib/src/meta/view.dart
@@ -1,3 +1,11 @@
+// TODO: review if this enum at
+//    > ngdart/lib/src/meta/view.dart
+// and the similar enum at
+//    > ngcompiler/lib/v1/src/compiler/ir/model.dart
+// could be merged as there is a conversion at
+//    > ngcompiler/lib/v1/src/compiler/angular_compiler.dart:118
+
+
 /// Defines template and style encapsulation options available for Component's
 /// [View].
 ///

--- a/ngdart/lib/src/meta/view.dart
+++ b/ngdart/lib/src/meta/view.dart
@@ -5,7 +5,6 @@
 // could be merged as there is a conversion at
 //    > ngcompiler/lib/v1/src/compiler/angular_compiler.dart:118
 
-
 /// Defines template and style encapsulation options available for Component's
 /// [View].
 ///

--- a/tests/pubspec.yaml
+++ b/tests/pubspec.yaml
@@ -1,7 +1,7 @@
-name: _tests
-description: Tests for AngularDart.
+name: _new_tests
+description: New Tests for AngularDart.
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   # No strict dependencies, we always use dependency_overrides.

--- a/tests/test/devtools/inspector_test.dart
+++ b/tests/test/devtools/inspector_test.dart
@@ -23,7 +23,7 @@ void main() {
   group('getComponents', () {
     test('component views', () async {
       final testBed =
-          NgTestBed<TestComponentViews>(ng.createTestComponentViewsFactory());
+          NgTestBed<TestComponentViews>(ng.createTestComponentViewsFactory() as ComponentFactory<TestComponentViews>);
       await testBed.create();
 
       final components = Inspector.instance.getComponents(groupName);
@@ -53,7 +53,7 @@ void main() {
     group('embedded views', () {
       test('conditional', () async {
         final testBed = NgTestBed<TestConditionalEmbeddedViews>(
-            ng.createTestConditionalEmbeddedViewsFactory());
+            ng.createTestConditionalEmbeddedViewsFactory() as ComponentFactory<TestConditionalEmbeddedViews>);
         final testFixture = await testBed.create();
 
         // Should not return embedded component before it's created.
@@ -95,7 +95,7 @@ void main() {
 
       test('repeated', () async {
         final testBed = NgTestBed<TestRepeatedEmbeddedViews>(
-            ng.createTestRepeatedEmbeddedViewsFactory());
+            ng.createTestRepeatedEmbeddedViewsFactory() as ComponentFactory<TestRepeatedEmbeddedViews>);
         final testFixture = await testBed.create(
           beforeChangeDetection: (component) {
             component.values = [1, 2, 4];
@@ -156,7 +156,7 @@ void main() {
 
       test('transplanted', () async {
         final testBed = NgTestBed<TestTransplantedEmbeddedViews>(
-            ng.createTestTransplantedEmbeddedViewsFactory());
+            ng.createTestTransplantedEmbeddedViewsFactory() as ComponentFactory<TestTransplantedEmbeddedViews>);
         await testBed.create();
 
         final components = Inspector.instance.getComponents(groupName);
@@ -183,7 +183,7 @@ void main() {
     });
 
     test('host views', () async {
-      final testBed = NgTestBed<TestHostViews>(ng.createTestHostViewsFactory());
+      final testBed = NgTestBed<TestHostViews>(ng.createTestHostViewsFactory() as ComponentFactory<TestHostViews>);
       final testFixture = await testBed.create();
 
       // Should not return imperatively loaded component before it's created.
@@ -225,7 +225,7 @@ void main() {
 
     test('projected content', () async {
       final testBed = NgTestBed<TestProjectedContent>(
-          ng.createTestProjectedContentFactory());
+          ng.createTestProjectedContentFactory() as ComponentFactory<TestProjectedContent>);
       await testBed.create();
 
       final components = Inspector.instance.getComponents(groupName);
@@ -269,7 +269,7 @@ void main() {
       setUp(() async {
         container = createContentRoot();
         final testBed = NgTestBed<TestExternalContentRoots>(
-            ng.createTestExternalContentRootsFactory());
+            ng.createTestExternalContentRootsFactory() as ComponentFactory<TestExternalContentRoots>);
         testFixture = await testBed.create();
       });
 
@@ -318,7 +318,7 @@ void main() {
       final containerOne = createContentRoot();
       final containerTwo = createContentRoot();
       final testBed = NgTestBed<TestExternalContentRoots>(
-          ng.createTestExternalContentRootsFactory());
+          ng.createTestExternalContentRootsFactory() as ComponentFactory<TestExternalContentRoots>);
       final testFixture = await testBed.create();
 
       await testFixture.update((component) {
@@ -339,7 +339,7 @@ void main() {
 
     test('is coalesced by existing content root', () async {
       final testBed = NgTestBed<TestExternalContentRoots>(
-          ng.createTestExternalContentRootsFactory());
+          ng.createTestExternalContentRootsFactory() as ComponentFactory<TestExternalContentRoots>);
       final testFixture = await testBed.create();
       final container = createContentRoot(parent: testFixture.rootElement);
 
@@ -356,7 +356,7 @@ void main() {
 
     test('coalesces existing content roots', () async {
       final testBed = NgTestBed<TestExternalContentRoots>(
-          ng.createTestExternalContentRootsFactory());
+          ng.createTestExternalContentRootsFactory() as ComponentFactory<TestExternalContentRoots>);
       final testFixture = await testBed.create();
       final childContainer = html.DivElement();
       final parentContainer = testFixture.rootElement.parent!
@@ -391,7 +391,7 @@ void main() {
   group('getNodes', () {
     test('component views', () async {
       final testBed =
-          NgTestBed<TestComponentViews>(ng.createTestComponentViewsFactory());
+          NgTestBed<TestComponentViews>(ng.createTestComponentViewsFactory() as ComponentFactory<TestComponentViews>);
       await testBed.create();
 
       expect(
@@ -412,7 +412,7 @@ void main() {
     group('embedded views', () {
       test('conditional', () async {
         final testBed = NgTestBed<TestConditionalEmbeddedViews>(
-            ng.createTestConditionalEmbeddedViewsFactory());
+            ng.createTestConditionalEmbeddedViewsFactory() as ComponentFactory<TestConditionalEmbeddedViews>);
         final testFixture = await testBed.create();
 
         // Should not return embedded component before it's created.
@@ -470,7 +470,7 @@ void main() {
 
       test('repeated', () async {
         final testBed = NgTestBed<TestRepeatedEmbeddedViews>(
-            ng.createTestRepeatedEmbeddedViewsFactory());
+            ng.createTestRepeatedEmbeddedViewsFactory() as ComponentFactory<TestRepeatedEmbeddedViews>);
         final testFixture = await testBed.create(
           beforeChangeDetection: (component) {
             component.values = [1, 2, 4];
@@ -539,7 +539,7 @@ void main() {
 
       test('transplated', () async {
         final testBed = NgTestBed<TestTransplantedEmbeddedViews>(
-            ng.createTestTransplantedEmbeddedViewsFactory());
+            ng.createTestTransplantedEmbeddedViewsFactory() as ComponentFactory<TestTransplantedEmbeddedViews>);
         await testBed.create();
 
         expect(
@@ -565,7 +565,7 @@ void main() {
     });
 
     test('host views', () async {
-      final testBed = NgTestBed<TestHostViews>(ng.createTestHostViewsFactory());
+      final testBed = NgTestBed<TestHostViews>(ng.createTestHostViewsFactory() as ComponentFactory<TestHostViews>);
       final testFixture = await testBed.create();
 
       // Should not return imperatively loaded component before it's created.
@@ -601,7 +601,7 @@ void main() {
 
     test('projected content', () async {
       final testBed = NgTestBed<TestProjectedContent>(
-          ng.createTestProjectedContentFactory());
+          ng.createTestProjectedContentFactory() as ComponentFactory<TestProjectedContent>);
       await testBed.create();
 
       expect(
@@ -634,7 +634,7 @@ void main() {
       setUp(() async {
         container = createContentRoot();
         final testBed = NgTestBed<TestExternalContentRoots>(
-            ng.createTestExternalContentRootsFactory());
+            ng.createTestExternalContentRootsFactory() as ComponentFactory<TestExternalContentRoots>);
         testFixture = await testBed.create();
       });
 
@@ -683,7 +683,7 @@ void main() {
       final containerOne = createContentRoot();
       final containerTwo = createContentRoot();
       final testBed = NgTestBed<TestExternalContentRoots>(
-          ng.createTestExternalContentRootsFactory());
+          ng.createTestExternalContentRootsFactory() as ComponentFactory<TestExternalContentRoots>);
       final testFixture = await testBed.create();
 
       await testFixture.update((component) {
@@ -704,7 +704,7 @@ void main() {
 
     test('is coalesced by existing content root', () async {
       final testBed = NgTestBed<TestExternalContentRoots>(
-          ng.createTestExternalContentRootsFactory());
+          ng.createTestExternalContentRootsFactory() as ComponentFactory<TestExternalContentRoots>);
       final testFixture = await testBed.create();
       final container = createContentRoot(parent: testFixture.rootElement);
 
@@ -721,7 +721,7 @@ void main() {
 
     test('coalesces existing content roots', () async {
       final testBed = NgTestBed<TestExternalContentRoots>(
-          ng.createTestExternalContentRootsFactory());
+          ng.createTestExternalContentRootsFactory() as ComponentFactory<TestExternalContentRoots>);
       final testFixture = await testBed.create();
       final childContainer = html.DivElement();
       final parentContainer = testFixture.rootElement.parent!
@@ -759,7 +759,7 @@ void main() {
 
     test('no inputs', () async {
       final testBed =
-          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory());
+          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory() as ComponentFactory<TestUsedInputs>);
       await testBed.create();
 
       final components = Inspector.instance.getComponents(groupName);
@@ -772,7 +772,7 @@ void main() {
 
     test('omits unused inputs', () async {
       final testBed =
-          NgTestBed<TestUnusedInputs>(ng.createTestUnusedInputsFactory());
+          NgTestBed<TestUnusedInputs>(ng.createTestUnusedInputsFactory() as ComponentFactory<TestUnusedInputs>);
       await testBed.create();
 
       final id = firstChildComponentId();
@@ -782,7 +782,7 @@ void main() {
 
     test('omits inputs until set', () async {
       final testBed =
-          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory());
+          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory() as ComponentFactory<TestUsedInputs>);
       final testFixture = await testBed.create();
 
       final id = firstChildComponentId();
@@ -809,7 +809,7 @@ void main() {
 
     test('updates inputs when changed', () async {
       final testBed =
-          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory());
+          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory() as ComponentFactory<TestUsedInputs>);
       final testFixture = await testBed.create(
         beforeChangeDetection: (component) {
           component.title = 'Hello!';
@@ -830,7 +830,7 @@ void main() {
 
     test('records immutable expressions', () async {
       final testBed =
-          NgTestBed<TestImmutableInputs>(ng.createTestImmutableInputsFactory());
+          NgTestBed<TestImmutableInputs>(ng.createTestImmutableInputsFactory() as ComponentFactory<TestImmutableInputs>);
       final testFixture = await testBed.create();
 
       final id = firstChildComponentId();
@@ -856,7 +856,7 @@ void main() {
 
     test('no inputs', () async {
       final testBed =
-          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory());
+          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory() as ComponentFactory<TestUsedInputs>);
       await testBed.create();
 
       final nodes = Inspector.instance.getNodes(groupName);
@@ -867,7 +867,7 @@ void main() {
 
     test('omits unused inputs', () async {
       final testBed =
-          NgTestBed<TestUnusedInputs>(ng.createTestUnusedInputsFactory());
+          NgTestBed<TestUnusedInputs>(ng.createTestUnusedInputsFactory() as ComponentFactory<TestUnusedInputs>);
       await testBed.create();
 
       final id = firstChildComponentId();
@@ -877,7 +877,7 @@ void main() {
 
     test('omits inputs until set', () async {
       final testBed =
-          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory());
+          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory() as ComponentFactory<TestUsedInputs>);
       final testFixture = await testBed.create();
 
       final id = firstChildComponentId();
@@ -904,7 +904,7 @@ void main() {
 
     test('updates inputs when changed', () async {
       final testBed =
-          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory());
+          NgTestBed<TestUsedInputs>(ng.createTestUsedInputsFactory() as ComponentFactory<TestUsedInputs>);
       final testFixture = await testBed.create(
         beforeChangeDetection: (component) {
           component.title = 'Hello!';
@@ -925,7 +925,7 @@ void main() {
 
     test('records immutable expressions', () async {
       final testBed =
-          NgTestBed<TestImmutableInputs>(ng.createTestImmutableInputsFactory());
+          NgTestBed<TestImmutableInputs>(ng.createTestImmutableInputsFactory() as ComponentFactory<TestImmutableInputs>);
       final testFixture = await testBed.create();
 
       final id = firstChildComponentId();
@@ -943,7 +943,7 @@ void main() {
 
     test('captures directive inputs', () async {
       final testBed = NgTestBed<TestConditionalEmbeddedViews>(
-          ng.createTestConditionalEmbeddedViewsFactory());
+          ng.createTestConditionalEmbeddedViewsFactory() as ComponentFactory<TestConditionalEmbeddedViews>);
       final testFixture = await testBed.create();
       final nodes = Inspector.instance.getNodes(groupName);
       final ngIfId = nodes.first.children.first.directives.first.id;
@@ -1076,7 +1076,7 @@ class TestEmbeddedViews2 {
   ''',
 )
 class TestHostViews {
-  final componentFactory = ng.createTestHostViews1Factory();
+  final componentFactory = ng.createTestHostViews1Factory() as ComponentFactory<TestHostViews1>;
 
   @ViewChild('viewContainerRef', read: ViewContainerRef)
   ViewContainerRef? viewContainerRef;

--- a/tests/test/directives/ng_for_content_projection_test.dart
+++ b/tests/test/directives/ng_for_content_projection_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     test('@ContentChildren', () async {
       fixture = await NgTestBed<TestNgForReorderContentChildren>(
-        ng.createTestNgForReorderContentChildrenFactory(),
+        ng.createTestNgForReorderContentChildrenFactory() as ComponentFactory<TestNgForReorderContentChildren>,
       ).create(
         beforeChangeDetection: (c) => c.items = [1, 2, 3],
       );
@@ -38,7 +38,7 @@ void main() {
 
     test('@ContentChildren, when nested', () async {
       fixture = await NgTestBed<TestNestedNgForReorderContentChildren>(
-              ng.createTestNestedNgForReorderContentChildrenFactory())
+              ng.createTestNestedNgForReorderContentChildrenFactory() as ComponentFactory<TestNestedNgForReorderContentChildren>)
           .create(
         beforeChangeDetection: (c) => c.items = [1, 2, 3],
       );
@@ -56,7 +56,7 @@ void main() {
 
     test('@ContentChildren, when nested with a #referenced child', () async {
       fixture = await NgTestBed<TestReferencedNgForReorderContentChildren>(
-              ng.createTestReferencedNgForReorderContentChildrenFactory())
+              ng.createTestReferencedNgForReorderContentChildrenFactory() as ComponentFactory<TestReferencedNgForReorderContentChildren>)
           .create(
         beforeChangeDetection: (c) => c.items = [1, 2, 3],
       );
@@ -75,7 +75,7 @@ void main() {
 
     test('@ViewChildren', () async {
       fixture = await NgTestBed<TestNgForReorderViewChildren>(
-              ng.createTestNgForReorderViewChildrenFactory())
+              ng.createTestNgForReorderViewChildrenFactory() as ComponentFactory<TestNgForReorderViewChildren>)
           .create(
         beforeChangeDetection: (c) => c.items = [1, 2, 3],
       );
@@ -93,7 +93,7 @@ void main() {
 
     test('@ViewChildren, when nested', () async {
       fixture = await NgTestBed<TestNestedNgForReorderViewChildren>(
-              ng.createTestNestedNgForReorderViewChildrenFactory())
+              ng.createTestNestedNgForReorderViewChildrenFactory() as ComponentFactory<TestNestedNgForReorderViewChildren>)
           .create(
         beforeChangeDetection: (c) => c.items = [1, 2, 3],
       );
@@ -111,7 +111,7 @@ void main() {
 
     test('@ViewChildren, when nested with a #referenced child', () async {
       fixture = await NgTestBed<TestReferencedNgForReorderViewChildren>(
-              ng.createTestReferencedNgForReorderViewChildrenFactory())
+              ng.createTestReferencedNgForReorderViewChildrenFactory() as ComponentFactory<TestReferencedNgForReorderViewChildren>)
           .create(
         beforeChangeDetection: (c) => c.items = [1, 2, 3],
       );

--- a/tests/test/lifecycle_hooks/after_changes_test.dart
+++ b/tests/test/lifecycle_hooks/after_changes_test.dart
@@ -9,7 +9,7 @@ void main() {
 
   test('should be called at least once on initial load', () async {
     final testBed =
-        NgTestBed<TestAfterChanges>(ng.createTestAfterChangesFactory());
+        NgTestBed<TestAfterChanges>(ng.createTestAfterChangesFactory() as ComponentFactory<TestAfterChanges>);
     final fixture = await testBed.create(beforeChangeDetection: (instance) {
       instance
         ..name = 'Buzz Lightyear'
@@ -21,7 +21,7 @@ void main() {
 
   test('should be called after there is a change to an @Input', () async {
     final testBed =
-        NgTestBed<TestAfterChanges>(ng.createTestAfterChangesFactory());
+        NgTestBed<TestAfterChanges>(ng.createTestAfterChangesFactory() as ComponentFactory<TestAfterChanges>);
     final fixture = await testBed.create();
     expect(fixture.text, isEmpty);
     expect(AfterChangesExample.ngAfterChangesCalled, 0);
@@ -43,7 +43,7 @@ void main() {
 
   test('should be skipped if inputs do not change identity', () async {
     final testBed =
-        NgTestBed<TestAfterChanges>(ng.createTestAfterChangesFactory());
+        NgTestBed<TestAfterChanges>(ng.createTestAfterChangesFactory() as ComponentFactory<TestAfterChanges>);
     final fixture = await testBed.create();
     expect(fixture.text, isEmpty);
     expect(AfterChangesExample.ngAfterChangesCalled, 0);
@@ -65,7 +65,7 @@ void main() {
 
   test('should also be supported on a @Directive', () async {
     final testBed = NgTestBed<TestAfterChangesDirective>(
-        ng.createTestAfterChangesDirectiveFactory());
+        ng.createTestAfterChangesDirectiveFactory() as ComponentFactory<TestAfterChangesDirective>);
     final fixture = await testBed.create(beforeChangeDetection: (instance) {
       instance.name = 'Buzz Lightyear';
     });

--- a/tests/test/lifecycle_hooks/do_check_test.dart
+++ b/tests/test/lifecycle_hooks/do_check_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   test('should call ngDoCheck initially', () async {
     final testBed =
-        NgTestBed<TestDoCheckHook>(ng.createTestDoCheckHookFactory());
+        NgTestBed<TestDoCheckHook>(ng.createTestDoCheckHookFactory() as ComponentFactory<TestDoCheckHook>);
     final fixture = await testBed.create(
       beforeChangeDetection: (i) => i.animals = ['Dog', 'Cat', 'Dog'],
     );
@@ -20,7 +20,7 @@ void main() {
 
   test('should call input setters initially', () async {
     final testBed =
-        NgTestBed<TestDoCheckSetter>(ng.createTestDoCheckSetterFactory());
+        NgTestBed<TestDoCheckSetter>(ng.createTestDoCheckSetterFactory() as ComponentFactory<TestDoCheckSetter>);
     final fixture = await testBed.create(
       beforeChangeDetection: (i) => i.animals = ['Dog', 'Cat', 'Dog'],
     );
@@ -29,7 +29,7 @@ void main() {
 
   test('should call ngDoCheck after each update', () async {
     final testBed =
-        NgTestBed<TestDoCheckHook>(ng.createTestDoCheckHookFactory());
+        NgTestBed<TestDoCheckHook>(ng.createTestDoCheckHookFactory() as ComponentFactory<TestDoCheckHook>);
     final fixture = await testBed.create(
       beforeChangeDetection: (i) => i.animals = ['Dog', 'Cat', 'Dog'],
     );
@@ -41,7 +41,7 @@ void main() {
 
   test('should call input setters only when changed', () async {
     final testBed =
-        NgTestBed<TestDoCheckSetter>(ng.createTestDoCheckSetterFactory());
+        NgTestBed<TestDoCheckSetter>(ng.createTestDoCheckSetterFactory() as ComponentFactory<TestDoCheckSetter>);
     final fixture = await testBed.create(
       beforeChangeDetection: (i) => i.animals = ['Dog', 'Cat', 'Dog'],
     );

--- a/tests/test/templates/additional_expression_test.dart
+++ b/tests/test/templates/additional_expression_test.dart
@@ -13,7 +13,7 @@ void main() {
 
   test('should parse identifiers from prefixed exports', () async {
     final fixture = await NgTestBed<TestPrefixedExports>(
-            ng.createTestPrefixedExportsFactory())
+            ng.createTestPrefixedExportsFactory() as ComponentFactory<TestPrefixedExports>)
         .create();
     expect(
       fixture.text,
@@ -31,7 +31,7 @@ void main() {
 
     setUp(() async {
       fixture = await NgTestBed<TestNonRootAssignment>(
-              ng.createTestNonRootAssignmentFactory())
+              ng.createTestNonRootAssignmentFactory() as ComponentFactory<TestNonRootAssignment>)
           .create();
     });
 
@@ -72,7 +72,7 @@ void main() {
 
   test('should parse null-aware method invocations', () async {
     final fixture = await NgTestBed<TestNullAwareFunctions>(
-            ng.createTestNullAwareFunctionsFactory())
+            ng.createTestNullAwareFunctionsFactory() as ComponentFactory<TestNullAwareFunctions>)
         .create();
     expect(
       fixture.text,


### PR DESCRIPTION
Fixes #12.

Refactor const lists to enums with values, fixing tests analyzer complains.