### PR TITLE
ci: switch to beta channel

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -156,22 +156,22 @@ jobs:
     needs:
       - job_001
   job_005:
-    name: "analyze; Dart dev; PKG: ngast; `dart analyze --fatal-infos`"
+    name: "analyze; Dart beta; PKG: ngast; `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngast;commands:analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngast;commands:analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngast
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngast
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngast_pub_upgrade
@@ -186,22 +186,22 @@ jobs:
     needs:
       - job_001
   job_006:
-    name: "analyze; Dart dev; PKGS: ngast, ngcompiler, ngdart; `dart format --output=none --set-exit-if-changed .`"
+    name: "analyze; Dart beta; PKGS: ngast, ngcompiler, ngdart; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngast-ngcompiler-ngdart;commands:format"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngast-ngcompiler-ngdart;commands:format"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngast-ngcompiler-ngdart
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngast-ngcompiler-ngdart
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngast_pub_upgrade
@@ -234,22 +234,22 @@ jobs:
     needs:
       - job_001
   job_007:
-    name: "analyze; Dart dev; PKGS: ngcompiler, ngdart; `dart analyze`"
+    name: "analyze; Dart beta; PKGS: ngcompiler, ngdart; `dart analyze`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngcompiler-ngdart;commands:analyze_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngcompiler-ngdart;commands:analyze_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngcompiler-ngdart
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngcompiler-ngdart
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngcompiler_pub_upgrade
@@ -624,22 +624,22 @@ jobs:
       - job_009
       - job_010
   job_017:
-    name: "build; Dart dev; PKG: _tests; `dart run build_runner build --fail-on-severe`"
+    name: "build; Dart beta; PKG: _tests; `dart run build_runner build --fail-on-severe`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_tests;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:_tests;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_tests
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:_tests
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: _tests_pub_upgrade
@@ -663,22 +663,22 @@ jobs:
       - job_009
       - job_010
   job_018:
-    name: "build; Dart dev; PKG: ngast; `dart run build_runner build --fail-on-severe`"
+    name: "build; Dart beta; PKG: ngast; `dart run build_runner build --fail-on-severe`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngast;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngast;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngast
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngast
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngast_pub_upgrade
@@ -702,22 +702,22 @@ jobs:
       - job_009
       - job_010
   job_019:
-    name: "build; Dart dev; PKG: ngcompiler; `dart run build_runner build --fail-on-severe`"
+    name: "build; Dart beta; PKG: ngcompiler; `dart run build_runner build --fail-on-severe`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngcompiler;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngcompiler;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngcompiler
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngcompiler
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngcompiler_pub_upgrade
@@ -741,22 +741,22 @@ jobs:
       - job_009
       - job_010
   job_020:
-    name: "build; Dart dev; PKG: ngforms; `dart run build_runner build --fail-on-severe`"
+    name: "build; Dart beta; PKG: ngforms; `dart run build_runner build --fail-on-severe`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngforms;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngforms;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngforms
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngforms
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngforms_pub_upgrade
@@ -780,22 +780,22 @@ jobs:
       - job_009
       - job_010
   job_021:
-    name: "build; Dart dev; PKG: ngrouter; `dart run build_runner build --fail-on-severe`"
+    name: "build; Dart beta; PKG: ngrouter; `dart run build_runner build --fail-on-severe`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngrouter;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngrouter;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngrouter
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngrouter
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngrouter_pub_upgrade
@@ -819,22 +819,22 @@ jobs:
       - job_009
       - job_010
   job_022:
-    name: "build; Dart dev; PKG: ngtest; `dart run build_runner build --fail-on-severe`"
+    name: "build; Dart beta; PKG: ngtest; `dart run build_runner build --fail-on-severe`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngtest;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngtest;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngtest
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngtest
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngtest_pub_upgrade
@@ -1491,22 +1491,22 @@ jobs:
       - job_027
       - job_028
   job_036:
-    name: "unit_test; Dart dev; PKG: _tests; `dart run build_runner test --fail-on-severe -- -P browser`"
+    name: "unit_test; Dart beta; PKG: _tests; `dart run build_runner test --fail-on-severe -- -P browser`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_tests;commands:command_2"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:_tests;commands:command_2"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_tests
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:_tests
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: _tests_pub_upgrade
@@ -1548,22 +1548,22 @@ jobs:
       - job_027
       - job_028
   job_037:
-    name: "unit_test; Dart dev; PKG: _tests; `dart run test -P vm`"
+    name: "unit_test; Dart beta; PKG: _tests; `dart run test -P vm`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_tests;commands:command_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:_tests;commands:command_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_tests
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:_tests
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: _tests_pub_upgrade
@@ -1605,22 +1605,22 @@ jobs:
       - job_027
       - job_028
   job_038:
-    name: "unit_test; Dart dev; PKG: ngast; `dart run build_runner test --fail-on-severe -- -P ci`"
+    name: "unit_test; Dart beta; PKG: ngast; `dart run build_runner test --fail-on-severe -- -P ci`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngast;commands:command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngast;commands:command_3"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngast
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngast
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngast_pub_upgrade
@@ -1662,22 +1662,22 @@ jobs:
       - job_027
       - job_028
   job_039:
-    name: "unit_test; Dart dev; PKG: ngcompiler; `dart run build_runner test --fail-on-severe -- -P ci`"
+    name: "unit_test; Dart beta; PKG: ngcompiler; `dart run build_runner test --fail-on-severe -- -P ci`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngcompiler;commands:command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngcompiler;commands:command_3"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngcompiler
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngcompiler
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngcompiler_pub_upgrade
@@ -1719,22 +1719,22 @@ jobs:
       - job_027
       - job_028
   job_040:
-    name: "unit_test; Dart dev; PKG: ngforms; `dart run build_runner test --fail-on-severe -- -P ci`"
+    name: "unit_test; Dart beta; PKG: ngforms; `dart run build_runner test --fail-on-severe -- -P ci`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngforms;commands:command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngforms;commands:command_3"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngforms
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngforms
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngforms_pub_upgrade
@@ -1776,22 +1776,22 @@ jobs:
       - job_027
       - job_028
   job_041:
-    name: "unit_test; Dart dev; PKG: ngrouter; `dart run build_runner test --fail-on-severe -- -P ci`"
+    name: "unit_test; Dart beta; PKG: ngrouter; `dart run build_runner test --fail-on-severe -- -P ci`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngrouter;commands:command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngrouter;commands:command_3"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngrouter
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngrouter
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngrouter_pub_upgrade
@@ -1833,22 +1833,22 @@ jobs:
       - job_027
       - job_028
   job_042:
-    name: "unit_test; Dart dev; PKG: ngtest; `dart run build_runner test --fail-on-severe -- -P ci`"
+    name: "unit_test; Dart beta; PKG: ngtest; `dart run build_runner test --fail-on-severe -- -P ci`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngtest;commands:command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngtest;commands:command_3"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:ngtest
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:ngtest
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: ngtest_pub_upgrade

--- a/_tests/mono_pkg.yaml
+++ b/_tests/mono_pkg.yaml
@@ -1,5 +1,5 @@
 sdk:
-  - dev
+  - beta
   - stable
   - 2.17.0
 

--- a/examples/hello_world/_mono_pkg.yaml
+++ b/examples/hello_world/_mono_pkg.yaml
@@ -1,5 +1,5 @@
 sdk:
-  - dev
+  - beta
   - stable
   - 2.17.0
 

--- a/ngast/mono_pkg.yaml
+++ b/ngast/mono_pkg.yaml
@@ -1,5 +1,5 @@
 sdk:
-  - dev
+  - beta
   - stable
   - 2.17.0
 

--- a/ngcompiler/mono_pkg.yaml
+++ b/ngcompiler/mono_pkg.yaml
@@ -1,5 +1,5 @@
 sdk:
-  - dev
+  - beta
   - stable
   - 2.17.0
 

--- a/ngdart/mono_pkg.yaml
+++ b/ngdart/mono_pkg.yaml
@@ -1,5 +1,5 @@
 sdk:
-  - dev
+  - beta
   - stable
   - 2.17.0
 

--- a/ngforms/mono_pkg.yaml
+++ b/ngforms/mono_pkg.yaml
@@ -1,5 +1,5 @@
 sdk:
-  - dev
+  - beta
   - stable
   - 2.17.0
 

--- a/ngrouter/mono_pkg.yaml
+++ b/ngrouter/mono_pkg.yaml
@@ -1,5 +1,5 @@
 sdk:
-  - dev
+  - beta
   - stable
   - 2.17.0
 

--- a/ngtest/mono_pkg.yaml
+++ b/ngtest/mono_pkg.yaml
@@ -1,5 +1,5 @@
 sdk:
-  - dev
+  - beta
   - stable
   - 2.17.0
 


### PR DESCRIPTION
`dev` seems to be failing because of some API removal in the `test` package.

Signed-off-by: Gavin Zhao <git@gzgz.dev>
