### PR TITLE
refactor: migrate to analyzer v5

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -27,7 +27,7 @@ analyzer:
     # Temporary exclusions: Can be removed in the future.
     # =====================
     # Re-enable once we no longer have 200+ analyzer related deprecations.
-    deprecated_member_use: ignore
+    # deprecated_member_use: ignore
     # Re-enable this once unused parameters are exempted (e.g. callback(_) {}).
     inference_failure_on_untyped_parameter: ignore
 

--- a/ngcompiler/lib/v1/src/angular_compiler/analyzer/common.dart
+++ b/ngcompiler/lib/v1/src/angular_compiler/analyzer/common.dart
@@ -14,7 +14,7 @@ String getTypeImport(DartType type) {
     return 'dart:core';
   }
   if (type is InterfaceType) {
-    return normalizeUrl(type.element.library.source.uri).toString();
+    return normalizeUrl(type.element2.library.source.uri).toString();
   }
   throw UnimplementedError('(${type.runtimeType}) $type');
 }
@@ -32,7 +32,7 @@ String? getTypeName(DartType type) {
     return null;
   }
   if (type is InterfaceType) {
-    return type.element.name;
+    return type.element2.name;
   }
   if (type is VoidType) {
     return 'void';
@@ -68,13 +68,13 @@ String? typeToCode(DartType? type) {
   } else if (type is InterfaceType) {
     var typeArguments = type.typeArguments;
     if (typeArguments.isEmpty) {
-      return type.element.name;
+      return type.element2.name;
     } else {
       final typeArgumentsStr = typeArguments.map(typeToCode).join(', ');
-      return '${type.element.name}<$typeArgumentsStr>';
+      return '${type.element2.name}<$typeArgumentsStr>';
     }
   } else if (type is TypeParameterType) {
-    return type.element.name;
+    return type.element2.name;
   } else if (type.isVoid) {
     return 'void';
   } else {
@@ -93,7 +93,7 @@ Uri urlOf(Element? element, [String? name]) {
   }
 
   var fragment = name ?? element!.name;
-  final enclosing = element!.enclosingElement;
+  final enclosing = element!.enclosingElement3;
   if (enclosing is ClassElement) {
     fragment = '${enclosing.name}.$fragment';
   }

--- a/ngcompiler/lib/v1/src/angular_compiler/analyzer/di/modules.dart
+++ b/ngcompiler/lib/v1/src/angular_compiler/analyzer/di/modules.dart
@@ -29,7 +29,7 @@ class ModuleReader {
   /// Validation may not be performed on the underlying elements.
   @protected
   bool isModule(DartObject o) =>
-      isList(o) || o.type?.element != null && $Module.isExactlyType(o.type!);
+      isList(o) || o.type?.element2 != null && $Module.isExactlyType(o.type!);
 
   /// Helper method that can recursively extract [DartObject]s for `Provider`.
   ///

--- a/ngcompiler/lib/v1/src/angular_compiler/analyzer/di/providers.dart
+++ b/ngcompiler/lib/v1/src/angular_compiler/analyzer/di/providers.dart
@@ -55,7 +55,7 @@ class ProviderReader {
       return _parseUseClass(
         token,
         o,
-        useClass.typeValue.element as ClassElement,
+        useClass.typeValue.element2 as ClassElement,
       );
     }
     final useFactory = reader.read('useFactory');
@@ -90,7 +90,7 @@ class ProviderReader {
       return _parseUseClass(
         token,
         o,
-        reader.read('token').typeValue.element as ClassElement,
+        reader.read('token').typeValue.element2 as ClassElement,
       );
     }
     throw UnsupportedProviderException(o, 'Could not parse provider');
@@ -186,7 +186,7 @@ class ProviderReader {
   /// Returns a provider element representing a single type.
   ProviderElement _parseTypeAsImplicitClassProvider(DartObject o) {
     final reader = ConstantReader(o);
-    final element = reader.typeValue.element;
+    final element = reader.typeValue.element2;
     if (element is ClassElement) {
       final token = linkTypeOf(element.thisType);
       return UseClassProviderElement(

--- a/ngcompiler/lib/v1/src/angular_compiler/analyzer/di/tokens.dart
+++ b/ngcompiler/lib/v1/src/angular_compiler/analyzer/di/tokens.dart
@@ -57,7 +57,7 @@ class TokenReader {
     late List<DartType> typeArgs;
     if (!$OpaqueToken.isExactlyType(valueType) &&
         !$MultiToken.isExactlyType(valueType)) {
-      final clazz = valueType.element;
+      final clazz = valueType.element2;
       if (clazz is ClassElement) {
         typeArgs = clazz.supertype!.typeArguments;
       }
@@ -83,21 +83,22 @@ class TokenReader {
   /// generation.
   TypeLink linkToOpaqueToken(DartType type) {
     if (!$OpaqueToken.isAssignableFromType(type)) {
-      throw BuildError.forElement(type.element!, 'Must implement OpaqueToken.');
+      throw BuildError.forElement(
+          type.element2!, 'Must implement OpaqueToken.');
     }
     if ($OpaqueToken.isExactlyType(type) || $MultiToken.isExactlyType(type)) {
       return linkTypeOf(type);
     }
-    final clazz = type.element as ClassElement;
+    final clazz = type.element2 as ClassElement;
     if (clazz.interfaces.isNotEmpty || clazz.mixins.isNotEmpty) {
       throw BuildError.forElement(
-        type.element!,
+        type.element2!,
         'A sub-type of OpaqueToken cannot implement or mixin any interfaces.',
       );
     }
     if (clazz.isPrivate || clazz.isAbstract) {
       throw BuildError.forElement(
-        type.element!,
+        type.element2!,
         'Must not be abstract or a private (i.e. prefixed with `_`) class.',
       );
     }
@@ -109,7 +110,7 @@ class TokenReader {
       var supertypeName =
           clazz.supertype!.getDisplayString(withNullability: false);
       throw BuildError.forElement(
-        type.element!,
+        type.element2!,
         ''
         'A sub-type of OpaqueToken must have a single unnamed const '
         'constructor with no parameters or type parameters. For example, '
@@ -124,7 +125,7 @@ class TokenReader {
     if (!$OpaqueToken.isExactlyType(clazz.supertype!) &&
         !$MultiToken.isExactlyType(clazz.supertype!)) {
       throw BuildError.forElement(
-        type.element!,
+        type.element2!,
         ''
         'A sub-type of OpaqueToken must directly extend OpaqueToken or '
         'MultiToken, and cannot extend another class that in turn extends '

--- a/ngcompiler/lib/v1/src/angular_compiler/analyzer/view/directive.dart
+++ b/ngcompiler/lib/v1/src/angular_compiler/analyzer/view/directive.dart
@@ -66,12 +66,12 @@ class DirectiveVisitor {
   /// **NOTE**: There is no verification [element] has the annotation.
   void visitDirective(ClassElement element) {
     for (final superType in element.allSupertypes.reversed) {
-      _visitDirectiveOrSupertype(superType.element);
+      _visitDirectiveOrSupertype(superType.element2);
     }
     _visitDirectiveOrSupertype(element);
   }
 
-  void _visitDirectiveOrSupertype(ClassElement element) {
+  void _visitDirectiveOrSupertype(InterfaceElement element) {
     for (final accessor in element.accessors) {
       _visitMember(accessor);
     }

--- a/ngcompiler/lib/v1/src/angular_compiler/analyzer/view/typed_reader.dart
+++ b/ngcompiler/lib/v1/src/angular_compiler/analyzer/view/typed_reader.dart
@@ -99,10 +99,10 @@ class TypedReader {
   TypedElement _parseTyped(DartObject typedObject, {bool root = false}) {
     final type = typeArgumentOf(typedObject);
     if (type is ParameterizedType && type.typeArguments.isNotEmpty) {
-      if (root && !$Directive.hasAnnotationOf(type.element!)) {
+      if (root && !$Directive.hasAnnotationOf(type.element2!)) {
         throw BuildError.withoutContext(
           'Expected a "Typed" expression with a "Component" or "Directive" '
-          'annotated type, but got "Typed<${type.name}>"',
+          'annotated type, but got "Typed<${type.getDisplayString(withNullability: true)}>"',
         );
       }
       String? on;
@@ -127,7 +127,7 @@ class TypedReader {
       for (final typeArgument in typeArguments) {
         if (typeArgument.isPrivate) {
           throw BuildError.withoutContext(
-            'Directive type arguments must be public, but "${type.name}" was '
+            'Directive type arguments must be public, but "${type.getDisplayString(withNullability: true)}" was '
             'given private type argument "${typeArgument.symbol}" by '
             '"${_hostElement.name}".',
           );

--- a/ngcompiler/lib/v1/src/compiler/analyzed_class.dart
+++ b/ngcompiler/lib/v1/src/compiler/analyzed_class.dart
@@ -99,13 +99,13 @@ String typeToCode(DartType type) {
   } else if (type is InterfaceType) {
     var typeArguments = type.typeArguments;
     if (typeArguments.isEmpty) {
-      return type.element.name;
+      return type.element2.name;
     } else {
       final typeArgumentsStr = typeArguments.map(typeToCode).join(', ');
-      return '${type.element.name}<$typeArgumentsStr>';
+      return '${type.element2.name}<$typeArgumentsStr>';
     }
   } else if (type is TypeParameterType) {
-    return type.element.name;
+    return type.element2.name;
   } else if (type.isVoid) {
     return 'void';
   } else {
@@ -365,7 +365,7 @@ class _TypeResolver extends ast.AstVisitor<DartType, dynamic> {
   DartType _lookupGetterReturnType(DartType receiverType, String getterName) {
     if (receiverType is InterfaceType) {
       var getter =
-          receiverType.lookUpGetter2(getterName, receiverType.element.library);
+          receiverType.lookUpGetter2(getterName, receiverType.element2.library);
       if (getter != null) return getter.returnType;
     }
     return _dynamicType;
@@ -377,7 +377,7 @@ class _TypeResolver extends ast.AstVisitor<DartType, dynamic> {
   DartType _lookupMethodReturnType(DartType receiverType, String methodName) {
     if (receiverType is InterfaceType) {
       var method =
-          receiverType.lookUpMethod2(methodName, receiverType.element.library);
+          receiverType.lookUpMethod2(methodName, receiverType.element2.library);
       if (method != null) return method.returnType;
     }
     return _dynamicType;

--- a/ngcompiler/lib/v1/src/compiler/output/convert.dart
+++ b/ngcompiler/lib/v1/src/compiler/output/convert.dart
@@ -32,12 +32,12 @@ o.OutputType? fromDartType(DartType? dartType, {bool resolveBounds = true}) {
   if (dartType is FunctionType) {
     return fromFunctionType(dartType);
   }
-  if (dartType.element!.isPrivate) {
+  if (dartType.element2!.isPrivate) {
     return o.DYNAMIC_TYPE;
   }
   if (dartType is TypeParameterType && resolveBounds) {
     // Resolve generic type to its bound or dynamic if it has none.
-    final dynamicType = dartType.element.library!.typeProvider.dynamicType;
+    final dynamicType = dartType.element2.library!.typeProvider.dynamicType;
     dartType = dartType.resolveToBound(dynamicType);
   }
   // Note this check for dynamic should come after the check for a type
@@ -61,7 +61,7 @@ o.OutputType? fromDartType(DartType? dartType, {bool resolveBounds = true}) {
   var outputType = o.ExternalType(
     CompileIdentifierMetadata(
       name: dartType.name!,
-      moduleUrl: moduleUrl(dartType.element!),
+      moduleUrl: moduleUrl(dartType.element2!),
       // Most o.ExternalTypes are not created, but those that are (like
       // OpaqueToken<...> need this generic type.
       typeArguments: typeArguments,

--- a/ngcompiler/lib/v1/src/compiler/template_ast.dart
+++ b/ngcompiler/lib/v1/src/compiler/template_ast.dart
@@ -187,7 +187,7 @@ class VariableAst implements TemplateAst {
   /// local variable declaration.
   DartType? dartType;
 
-  OutputType? get type => fromDartType(dartType, resolveBounds: false);
+  OutputType? get type => fromDartTypeNoResolve(dartType);
 
   VariableAst(this.name, String? value, this.sourceSpan)
       : value = value != null && value.isNotEmpty ? value : implicitValue;

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/compile_metadata.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/compile_metadata.dart
@@ -255,7 +255,7 @@ class CompileTypeMetadataVisitor
     for (final typeParameter in element.typeParameters) {
       typeParameters.add(o.TypeParameter(
         typeParameter.name,
-        bound: fromDartType(typeParameter.bound, resolveBounds: false),
+        bound: fromDartTypeNoResolve(typeParameter.bound),
       ));
     }
     return CompileTypeMetadata(
@@ -267,7 +267,8 @@ class CompileTypeMetadataVisitor
             : [],
         element,
       ),
-      typeArguments: List.from(typeArguments.map(fromDartType)),
+      typeArguments: List.from(typeArguments.map(
+          (DartType type) => fromDartType(type, _library.element.typeSystem))),
       typeParameters: typeParameters,
     );
   }

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/compile_metadata.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/compile_metadata.dart
@@ -92,7 +92,7 @@ class CompileTypeMetadataVisitor
         ).toString());
         return null;
       }
-      var metadata = visitClassElement(type.element);
+      var metadata = visitClassElement(type.element2 as ClassElement);
       final tokenMetadata = CompileTokenMetadata(identifier: metadata);
       _preventProvidingGlobalSingletonService(tokenMetadata);
       return CompileProviderMetadata(
@@ -111,7 +111,7 @@ class CompileTypeMetadataVisitor
     }
     final providerType = inferProviderType(provider, token);
     final providerTypeArgument = providerType is InterfaceType
-        ? _getCompileTypeMetadata(providerType.element,
+        ? _getCompileTypeMetadata(providerType.element2 as ClassElement,
             typeArguments: providerType.typeArguments)
         : null;
 
@@ -181,7 +181,7 @@ class CompileTypeMetadataVisitor
       var type = maybeUseClass!.toTypeValue();
       if (type is InterfaceType) {
         return _getCompileTypeMetadata(
-          type.element,
+          type.element2 as ClassElement,
           enforceClassCanBeCreated: true,
         );
       } else {
@@ -195,7 +195,7 @@ class CompileTypeMetadataVisitor
       final typeValue = token.toTypeValue();
       if (typeValue != null && !typeValue.isDartCoreNull) {
         return _getCompileTypeMetadata(
-          typeValue.element as ClassElement,
+          typeValue.element2 as ClassElement,
           enforceClassCanBeCreated: true,
         );
       }
@@ -231,10 +231,10 @@ class CompileTypeMetadataVisitor
         // be a [FunctionTypedElement].
         var type = maybeUseFactory.type!;
         throw BuildError.forElement(
-          type.element!,
+          type.element2!,
           'Provider.useFactory must be a Function, but got type'
           '$type instead with type element '
-          '${type.element}',
+          '${type.element2}',
         );
       }
     }
@@ -334,7 +334,7 @@ class CompileTypeMetadataVisitor
       // not have something annotated properly. It's likely this is either
       // dead code or is not actually used via DI. We can ignore for now.
       logWarning(''
-          'Could not resolve token for $p on ${p.enclosingElement} in '
+          'Could not resolve token for $p on ${p.enclosingElement3} in '
           '${p.library?.identifier}');
       return CompileDiDependencyMetadata();
     }
@@ -421,10 +421,10 @@ class CompileTypeMetadataVisitor
         }
       }
       return _tokenForType(token.type, isInstance: invocation != null);
-    } else if (token.type!.element is FunctionTypedElement) {
+    } else if (token.type!.element2 is FunctionTypedElement) {
       return CompileTokenMetadata(
           identifier: _identifierForFunction(
-              token.type!.element as FunctionTypedElement));
+              token.type!.element2 as FunctionTypedElement));
     }
     throw ArgumentError('@Inject is not yet supported for $token.');
   }
@@ -474,9 +474,9 @@ class CompileTypeMetadataVisitor
     Element? element = type.alias?.element;
     if (element == null) {
       if (type is DynamicType) {
-        element = type.element;
+        element = type.element2;
       } else if (type is InterfaceType) {
-        element = type.element;
+        element = type.element2;
       }
     }
     if (element == null) {
@@ -520,9 +520,9 @@ class CompileTypeMetadataVisitor
       return _expressionForType(token);
     } else if (token.toFunctionValue() != null) {
       return o.importExpr(_identifierForFunction(token.toFunctionValue()!));
-    } else if (token.type!.element is FunctionTypedElement) {
+    } else if (token.type!.element2 is FunctionTypedElement) {
       return o.importExpr(
-          _identifierForFunction(token.type!.element as FunctionTypedElement));
+          _identifierForFunction(token.type!.element2 as FunctionTypedElement));
     } else {
       throw ArgumentError('Could not create useValue expression for $token');
     }
@@ -567,8 +567,8 @@ class CompileTypeMetadataVisitor
   CompileIdentifierMetadata _identifierForFunction(
       FunctionTypedElement function) {
     String? prefix;
-    if (function.enclosingElement is ClassElement) {
-      prefix = function.enclosingElement!.name;
+    if (function.enclosingElement3 is ClassElement) {
+      prefix = function.enclosingElement3!.name;
     }
     return CompileIdentifierMetadata(
         name: function.name!,
@@ -582,8 +582,8 @@ class CompileTypeMetadataVisitor
     List<DartObject> typesOrTokens,
   ) {
     String? prefix;
-    if (function.enclosingElement is ClassElement) {
-      prefix = function.enclosingElement!.name;
+    if (function.enclosingElement3 is ClassElement) {
+      prefix = function.enclosingElement3!.name;
     }
     return CompileFactoryMetadata(
       name: function.name!,
@@ -648,14 +648,15 @@ class CompileTypeMetadataVisitor
   }
 
   Iterable<FieldElement> _enumValues(DartObject token) {
-    final clazz = token.type!.element as ClassElement;
+    final clazz = token.type!.element2 as ClassElement;
     // Due to https://github.com/dart-lang/sdk/issues/29306, isEnumConstant is
     // not enough, so we also need to skip synthetic fields 'index' and 'value'.
     return clazz.fields
         .where((field) => field.isEnumConstant && !field.isSynthetic);
   }
 
-  bool _isEnum(DartType? type) => type is InterfaceType && type.element.isEnum;
+  bool _isEnum(DartType? type) =>
+      type is InterfaceType && type.element2 is EnumElement;
 
   bool _isProtobufEnum(DartType? type) {
     return type is InterfaceType &&

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/dart_object_utils.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/dart_object_utils.dart
@@ -89,7 +89,7 @@ Element? typeDeclarationOf(DartObject value) {
 
   // For functions, `toTypeValue()` is null so we fall back on `type`.
   final type = value.toTypeValue() ?? value.type;
-  return type?.element;
+  return type?.element2;
 }
 
 // TODO: For whatever reason 'ByName' works in Bazel, but not 'ByIndex', and the

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
@@ -340,7 +340,7 @@ class _ComponentVisitor
               _inputTypes[element.displayName] = CompileTypeMetadata(
                 moduleUrl: moduleUrl(element),
                 name: typeName,
-                typeArguments: List.from(typeArguments.map(fromDartType)),
+                typeArguments: List.from(typeArguments.map((DartType type) => fromDartType(type, _library.element.typeSystem))),
               );
             }
           }

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
@@ -487,7 +487,7 @@ class _ComponentVisitor
       CompileTokenMetadata(
         identifier: CompileIdentifierMetadata(
           name: selectorType.name!,
-          moduleUrl: moduleUrl(selectorType.element!),
+          moduleUrl: moduleUrl(selectorType.element2!),
         ),
       ),
     ];
@@ -508,7 +508,7 @@ class _ComponentVisitor
       descendants: coerceBool(value, 'descendants', defaultTo: false),
       first: coerceBool(value, 'first', defaultTo: false),
       propertyName: propertyName,
-      isElementType: propertyType?.element != null &&
+      isElementType: propertyType?.element2 != null &&
               _htmlElement.isAssignableFromType(propertyType!) ||
           // A bit imprecise, but this will cover 'Iterable' and 'List'.
           _coreIterable.isAssignableFromType(propertyType!) &&
@@ -519,7 +519,7 @@ class _ComponentVisitor
           ? CompileTokenMetadata(
               identifier: CompileIdentifierMetadata(
                 name: readType.displayName,
-                moduleUrl: moduleUrl(readType.element!),
+                moduleUrl: moduleUrl(readType.element2!),
               ),
             )
           : null,
@@ -541,7 +541,7 @@ class _ComponentVisitor
     var bindTo = ast.PropertyRead(ast.ImplicitReceiver(), element.name!);
     if (element is PropertyAccessorElement && element.isStatic ||
         element is FieldElement && element.isStatic) {
-      if (element.enclosingElement != _directiveClassElement) {
+      if (element.enclosingElement3 != _directiveClassElement) {
         // We do not want to inherit static members.
         // https://github.com/angulardart/angular/issues/1272
         return;
@@ -586,7 +586,7 @@ class _ComponentVisitor
     final propertyName = element.displayName;
     final bindingName =
         coerceString(value, 'bindingPropertyName', defaultTo: propertyName)!;
-    _prohibitBindingChange(element.enclosingElement as ClassElement?,
+    _prohibitBindingChange(element.enclosingElement3 as ClassElement?,
         propertyName, bindingName, immutableBindings ?? bindings);
     bindings[propertyName] = bindingName;
   }
@@ -620,7 +620,7 @@ class _ComponentVisitor
     // Reverse supertypes to traverse inheritance hierarchy from top to bottom
     // so that derived bindings overwrite their inherited definition.
     for (var type in element.allSupertypes.reversed) {
-      _collectInheritableMetadataOn(type.element);
+      _collectInheritableMetadataOn(type.element2 as ClassElement);
     }
     _collectInheritableMetadataOn(element);
   }

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/pipe_visitor.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/pipe_visitor.dart
@@ -76,7 +76,8 @@ class PipeVisitor extends RecursiveElementVisitor<CompilePipeMetadata> {
       type: annotation.element.accept(
         CompileTypeMetadataVisitor(_library, annotation, _exceptionHandler),
       )!,
-      transformType: fromFunctionType(transformType),
+      transformType:
+          fromFunctionType(transformType, _library.element.typeSystem),
       name: coerceString(value, 'name'),
       pure: coerceBool(value, 'pure', defaultTo: true),
       lifecycleHooks: extractLifecycleHooks(annotation.element),

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/provider_inference.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/provider_inference.dart
@@ -26,14 +26,14 @@ DartType? inferProviderType(DartObject provider, DartObject token) {
       return tokenType.typeArguments.first;
     }
     // Check for a _custom_ MultiToken<T>
-    final tokenTypeClass = tokenType.element;
+    final tokenTypeClass = tokenType.element2;
     if (tokenTypeClass is ClassElement) {
       var supertype = tokenTypeClass.supertype!;
       if (!$MultiToken.isExactlyType(supertype)) {
         // When we start using angular_compiler to resolve all of the time
         // remove this message, since we already validate there.
         throw BuildError.forElement(
-            tokenType.element!,
+            tokenType.element2!,
             'A sub-type of OpaqueToken must directly extend OpaqueToken or '
             'MultiToken, and cannot extend another class that in turn extends '
             'OpaqueToken or MultiToken.\n\n'

--- a/ngcompiler/test/v1/angular_compiler/analyzer/di/dependency_reader_test.dart
+++ b/ngcompiler/test/v1/angular_compiler/analyzer/di/dependency_reader_test.dart
@@ -66,7 +66,7 @@ void main() {
       ''');
     });
 
-    ClassElement? classNamed(String name) => library.getType(name);
+    ClassElement? classNamed(String name) => library.getClass(name);
 
     FunctionElement functionNamed(String name) =>
         library.definingCompilationUnit.functions

--- a/ngcompiler/test/v1/angular_compiler/analyzer/di/module_reader_test.dart
+++ b/ngcompiler/test/v1/angular_compiler/analyzer/di/module_reader_test.dart
@@ -61,8 +61,8 @@ void main() {
           ],
         );
       ''');
-      $Example = testLib.getType('Example')!;
-      $Dependency = testLib.getType('Dependency')!;
+      $Example = testLib.getClass('Example')!;
+      $Dependency = testLib.getClass('Dependency')!;
       $listModule = $Example.metadata.first.computeConstantValue()!;
       $newModuleA = $Example.metadata[1].computeConstantValue()!;
       $newModuleB = $Example.metadata[2].computeConstantValue()!;
@@ -232,7 +232,7 @@ void main() {
         class C {}
       ''');
       final testObjects = List<DartObject>.from(testLib
-          .getType('Example')!
+          .getClass('Example')!
           .metadata
           .map((e) => e.computeConstantValue()));
       aListOfProviders = testObjects[0];

--- a/ngcompiler/test/v1/angular_compiler/analyzer/di/provider_reader_test.dart
+++ b/ngcompiler/test/v1/angular_compiler/analyzer/di/provider_reader_test.dart
@@ -97,10 +97,10 @@ void main() {
           ),
         ];
       ''');
-      $Example = testLib.getType('Example')!;
-      $ExamplePrime = testLib.getType('ExamplePrime')!;
-      $DependencyA = testLib.getType('DependencyA')!;
-      $DependencyB = testLib.getType('DependencyB')!;
+      $Example = testLib.getClass('Example')!;
+      $ExamplePrime = testLib.getClass('ExamplePrime')!;
+      $DependencyA = testLib.getClass('DependencyA')!;
+      $DependencyB = testLib.getClass('DependencyB')!;
       $createExample = testLib.definingCompilationUnit.functions.first;
       $ExampleCreate = $Example.getMethod('create')!;
       providers =

--- a/ngcompiler/test/v1/angular_compiler/analyzer/di/token_reader_test.dart
+++ b/ngcompiler/test/v1/angular_compiler/analyzer/di/token_reader_test.dart
@@ -116,7 +116,7 @@ void main() {
     });
 
     InterfaceType instantiateClass(String name) {
-      final element = library.getType(name)!;
+      final element = library.getClass(name)!;
       return element.instantiate(
         typeArguments: List.filled(
           element.typeParameters.length,

--- a/ngcompiler/test/v1/angular_compiler/analyzer/types_test.dart
+++ b/ngcompiler/test/v1/angular_compiler/analyzer/types_test.dart
@@ -32,17 +32,17 @@ void main() {
     });
 
     test('@Directive', () {
-      final aDirective = testLib.getType('ADirective')!;
+      final aDirective = testLib.getClass('ADirective')!;
       expect($Directive.firstAnnotationOfExact(aDirective), isNotNull);
     });
 
     test('@Component', () {
-      final aComponent = testLib.getType('AComponent')!;
+      final aComponent = testLib.getClass('AComponent')!;
       expect($Component.firstAnnotationOfExact(aComponent), isNotNull);
     });
 
     test('@Injectable', () {
-      final anInjectable = testLib.getType('AnInjectable')!;
+      final anInjectable = testLib.getClass('AnInjectable')!;
       expect($Injectable.firstAnnotationOfExact(anInjectable), isNotNull);
     });
 

--- a/ngcompiler/test/v1/angular_compiler/analyzer/view/typed_reader_test.dart
+++ b/ngcompiler/test/v1/angular_compiler/analyzer/view/typed_reader_test.dart
@@ -240,7 +240,7 @@ void main() {
 
   group('throws', () {
     Future<void> parseTyped(LibraryElement element) async {
-      final example = element.getType('Example')!;
+      final example = element.getClass('Example')!;
       final typedReader = TypedReader(example);
       final typedValue = example.metadata.first.computeConstantValue()!;
       typedReader.parse(typedValue);
@@ -350,7 +350,7 @@ void main() {
         errors: [
           contains(
               'Expected a "Typed" expression with a "Component" or "Directive" '
-              'annotated type, but got "Typed<List>"')
+              'annotated type, but got "Typed<List<int>>"')
         ],
       );
     });
@@ -369,7 +369,7 @@ void main() {
         parseTyped,
         errors: [
           contains(
-              'Directive type arguments must be public, but "GenericComponent" '
+              'Directive type arguments must be public, but "GenericComponent<_Private>" '
               'was given private type argument "_Private" by "Example".')
         ],
       );

--- a/ngcompiler/test/v1/angular_compiler/src/resolve.dart
+++ b/ngcompiler/test/v1/angular_compiler/src/resolve.dart
@@ -48,6 +48,6 @@ Future<ClassElement?> resolveClass(
 ]) async {
   final library = await resolveLibrary(source);
   return name != null
-      ? library.getType(name)
+      ? library.getClass(name)
       : library.definingCompilationUnit.classes.first;
 }

--- a/ngcompiler/test/v2/testing/runtime_source_resolution_test.dart
+++ b/ngcompiler/test/v2/testing/runtime_source_resolution_test.dart
@@ -15,7 +15,7 @@ void main() {
     );
     expect(
       library
-          .getType('Example')!
+          .getClass('Example')!
           .metadata
           .first
           .computeConstantValue()!
@@ -37,7 +37,7 @@ void main() {
       includeAngularDeps: false,
     );
     expect(
-      library.getType('Example')!.metadata.first.computeConstantValue(),
+      library.getClass('Example')!.metadata.first.computeConstantValue(),
       isNull,
       reason: 'Angular was not loaded',
     );
@@ -57,7 +57,7 @@ void main() {
         AssetId('test_lib', 'lib/another.dart'): 'class Base {}'
       },
     );
-    final clazz = library.getType('Example')!;
+    final clazz = library.getClass('Example')!;
     expect(
       clazz.metadata.first
           .computeConstantValue()!
@@ -65,6 +65,6 @@ void main() {
           .toStringValue(),
       'Hello World',
     );
-    expect(clazz.supertype!.element.name, 'Base');
+    expect(clazz.supertype!.element2.name, 'Base');
   });
 }


### PR DESCRIPTION
Note: will bring the `deprecated_member_use: ignore` lint back since other projects still need it. For now, it's just for me to see the deprecations easier.