### PR TITLE
fix: mixins are not ClassElement

### DIFF
--- a/_tests/test/compiler_integration/invalid_component_test.dart
+++ b/_tests/test/compiler_integration/invalid_component_test.dart
@@ -373,6 +373,20 @@ void main() {
     ''');
   });
 
+  test('should support component with mixins', () {
+    return compilesNormally('''
+      import '$ngImport';
+
+      @Component(
+        selector: 'with-mixin',
+        template: '',
+      )
+      class WithMixinComponent with MyMixin {}
+
+      mixin MyMixin {}
+    ''');
+  });
+
   group('providers', () {
     test('should error on invalid token', () async {
       await compilesExpecting('''

--- a/ngcompiler/lib/v1/src/angular_compiler/analyzer/view/directive.dart
+++ b/ngcompiler/lib/v1/src/angular_compiler/analyzer/view/directive.dart
@@ -66,12 +66,12 @@ class DirectiveVisitor {
   /// **NOTE**: There is no verification [element] has the annotation.
   void visitDirective(ClassElement element) {
     for (final superType in element.allSupertypes.reversed) {
-      _visitDirectiveOrSupertype(superType.element as ClassElement);
+      _visitDirectiveOrSupertype(superType.element);
     }
     _visitDirectiveOrSupertype(element);
   }
 
-  void _visitDirectiveOrSupertype(ClassElement element) {
+  void _visitDirectiveOrSupertype(InterfaceElement element) {
     for (final accessor in element.accessors) {
       _visitMember(accessor);
     }

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
@@ -590,16 +590,16 @@ class _ComponentVisitor
     final propertyName = element.displayName;
     final bindingName =
         coerceString(value, 'bindingPropertyName', defaultTo: propertyName)!;
-    _prohibitBindingChange(element.enclosingElement as ClassElement?,
+    _prohibitBindingChange(element.enclosingElement as InterfaceElement?,
         propertyName, bindingName, immutableBindings ?? bindings);
     bindings[propertyName] = bindingName;
   }
 
   /// Collects inheritable metadata declared on [element].
-  void _collectInheritableMetadataOn(ClassElement element) {
+  void _collectInheritableMetadataOn(InterfaceElement element) {
     // Skip 'Object' since it can't have metadata and we only want to record
     // whether a user type implements 'noSuchMethod'.
-    if (element.isDartCoreObject) return;
+    if (element is ClassElement && element.isDartCoreObject) return;
 
     // Skip checking for noSuchMethod for opted-in libraries.
     if (!CompileContext.current.emitNullSafeCode &&
@@ -608,7 +608,7 @@ class _ComponentVisitor
     }
 
     // Collect metadata from field and property accessor annotations.
-    super.visitClassElement(element);
+    element.visitChildren(this);
 
     // Merge field and setter inputs, so that a derived field input binding is
     // not overridden by an inherited setter input.
@@ -624,7 +624,7 @@ class _ComponentVisitor
     // Reverse supertypes to traverse inheritance hierarchy from top to bottom
     // so that derived bindings overwrite their inherited definition.
     for (var type in element.allSupertypes.reversed) {
-      _collectInheritableMetadataOn(type.element as ClassElement);
+      _collectInheritableMetadataOn(type.element);
     }
     _collectInheritableMetadataOn(element);
   }
@@ -941,7 +941,7 @@ void _errorOnUnusedDirectiveTypes(
 }
 
 void _prohibitBindingChange(
-  ClassElement? element,
+  InterfaceElement? element,
   String propertyName,
   String? bindingName,
   Map<String, String?> bindings,


### PR DESCRIPTION
This PR solves the issue but i am not sure if this is correct approach. I would like to add tests if someone could point me where would be the best place.

I will mention @ykmnkmi as this is mostly his work.

When compiling this:

```
@Directive(selector: 'dir')
class MyDir with MyMixin {}

mixin MyMixin {}
```

you get this error:
```
type 'MixinElementImpl' is not a subtype of type 'ClassElement' in type cast.
```