### PR TITLE
fix(ngcompiler): declare types to be X instead of XImpl

### DIFF
--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/compile_metadata.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/compile_metadata.dart
@@ -364,7 +364,7 @@ class CompileTypeMetadataVisitor
 
   CompileTokenMetadata _annotationToToken(ElementAnnotationImpl annotation) {
     String name;
-    final id = annotation.annotationAst.arguments!.arguments.first;
+    final Expression id = annotation.annotationAst.arguments!.arguments.first;
     if (id is Identifier) {
       if (id is PrefixedIdentifier) {
         name = id.identifier.name;

--- a/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
+++ b/ngcompiler/lib/v1/src/source_gen/template_compiler/find_components.dart
@@ -150,7 +150,7 @@ class _NormalizedComponentVisitor extends RecursiveElementVisitor<void> {
       // template parsing in a similar way to #1, but a user will look at the
       // code and not see a problem potentially.
       final annotationImpl = annotation as ElementAnnotationImpl;
-      for (final argument
+      for (final Expression argument
           in annotationImpl.annotationAst.arguments!.arguments) {
         if (argument is NamedExpression && argument.name.label.name == field) {
           if (argument.expression is! ListLiteral) {
@@ -796,7 +796,7 @@ class _ComponentVisitor
             .annotationAst
             .arguments
             ?.arguments
-            .firstWhereOrNull((argument) =>
+            .firstWhereOrNull((Expression argument) =>
                 argument is NamedExpression &&
                 argument.name.label.name == 'template') as NamedExpression?;
     if (templateExpression != null) {


### PR DESCRIPTION
See dart-lang/sdk#51783. There may be other occurrences of the same issue, but let's fix these for now.